### PR TITLE
Wave 3: RAG generator, FastAPI endpoints, and Rich CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "neo4j>=5.20",
     "neo4j-graphrag>=1.5,<2.0",
     "sentence-transformers>=5.0",
+    "transformers>=5.0.0",
     "openai>=1.40",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",

--- a/src/stylemind/__main__.py
+++ b/src/stylemind/__main__.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import uuid
+
+import httpx
+import uvicorn
+
+from stylemind.cli.chat import ChatCLI
+
+_DEFAULT_PORT = 8000
+_HEALTH_TIMEOUT = 30
+_HEALTH_POLL_INTERVAL = 0.5
+
+
+def _start_server(port: int) -> None:
+    uvicorn.run("stylemind.main:create_app", factory=True, host="0.0.0.0", port=port, log_level="error")
+
+
+def _wait_for_server(port: int, timeout: int = _HEALTH_TIMEOUT) -> bool:
+    """Poll /health until ready or timeout."""
+    url = f"http://localhost:{port}/health"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            resp = httpx.get(url, timeout=2.0)
+            if resp.status_code == 200:
+                return True
+        except httpx.ConnectError, httpx.TimeoutException, httpx.ReadError:
+            pass
+        time.sleep(_HEALTH_POLL_INTERVAL)
+    return False
+
+
+def main() -> None:
+    port = int(os.environ.get("SERVER_PORT", str(_DEFAULT_PORT)))
+
+    thread = threading.Thread(target=_start_server, args=(port,), daemon=True)
+    thread.start()
+
+    print(f"Starting StyleMind server on port {port}...")
+    if not _wait_for_server(port):
+        print(f"ERROR: Server did not start within {_HEALTH_TIMEOUT}s.", file=sys.stderr)
+        sys.exit(1)
+
+    user_id = uuid.uuid4().hex[:8]
+    base_url = f"http://localhost:{port}"
+
+    cli = ChatCLI(base_url=base_url, user_id=user_id)
+    try:
+        cli.run()
+    except KeyboardInterrupt:
+        print("\nGoodbye! 👋")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stylemind/api/chat.py
+++ b/src/stylemind/api/chat.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
+
+from stylemind.models.schemas import ChatRequest, PersonaSnapshot
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+async def _sse_stream(
+    request: Request,
+    chat_request: ChatRequest,
+) -> AsyncGenerator[str]:
+    """Core SSE generator: retrieve → rerank → (outfit) → stream → fire-and-forget persona update."""
+    state = request.app.state
+
+    retriever = getattr(state, "retriever", None)
+    reranker = getattr(state, "reranker", None)
+    generator = getattr(state, "generator", None)
+    persona_manager = getattr(state, "persona_manager", None)
+    inference_engine = getattr(state, "inference_engine", None)
+    outfit_builder = getattr(state, "outfit_builder", None)
+
+    # 1. Get current persona (returns empty default on first turn, never None)
+    persona: PersonaSnapshot = PersonaSnapshot()
+    if persona_manager is not None:
+        try:
+            persona = persona_manager.get_persona(chat_request.user_id)
+        except Exception as exc:
+            logger.warning("chat get_persona failed user_id=%s error=%s", chat_request.user_id, exc)
+
+    # 2. Retrieve candidate products
+    retrieved_products = []
+    if retriever is not None:
+        try:
+            retrieved_products = retriever.retrieve(chat_request.message)
+        except Exception as exc:
+            logger.warning("chat retrieve failed user_id=%s error=%s", chat_request.user_id, exc)
+
+    # 3. Rerank with persona signals
+    reranked_products = retrieved_products
+    if reranker is not None and retrieved_products:
+        try:
+            rerank_results = reranker.rerank(retrieved_products, persona, explain=chat_request.explain)
+            reranked_products = [r.product for r in rerank_results]
+        except Exception as exc:
+            logger.warning("chat rerank failed user_id=%s error=%s", chat_request.user_id, exc)
+
+    # 4. Detect product interest → conditionally build outfit
+    outfit = None
+    if generator is not None and outfit_builder is not None and reranked_products:
+        try:
+            matched_product_id = generator.detect_product_interest(chat_request.message, reranked_products)
+            if matched_product_id:
+                try:
+                    outfit = outfit_builder.build_outfit(
+                        product_id=matched_product_id,
+                        user_id=chat_request.user_id,
+                        persona=persona,
+                    )
+                    logger.info("chat outfit built product_id=%s user_id=%s", matched_product_id, chat_request.user_id)
+                except Exception as exc:
+                    logger.warning("chat outfit build failed product_id=%s error=%s", matched_product_id, exc)
+        except Exception as exc:
+            logger.warning("chat detect_product_interest failed user_id=%s error=%s", chat_request.user_id, exc)
+
+    # 5. Stream LLM response
+    if generator is not None:
+        try:
+            async for chunk in generator.stream_response(
+                message=chat_request.message,
+                history=chat_request.history,
+                retrieved_products=reranked_products,
+                outfit=outfit,
+            ):
+                yield f"data: {chunk}\n\n"
+        except Exception as exc:
+            logger.error("chat stream_response failed user_id=%s error=%s", chat_request.user_id, exc)
+            yield "data: Sorry, an error occurred while generating the response.\n\n"
+    else:
+        yield "data: StyleMind generator not available.\n\n"
+
+    yield "data: [DONE]\n\n"
+
+    # 6. Fire-and-forget async persona update (does NOT block response)
+    if inference_engine is not None and persona_manager is not None:
+        shown_product_ids = [p.product_id for p in reranked_products]
+
+        async def _update_persona() -> None:
+            try:
+                signals = inference_engine.extract_signals(
+                    message=chat_request.message,
+                    history=chat_request.history,
+                    shown_products=shown_product_ids,
+                )
+                persona_manager.update_persona(chat_request.user_id, signals)
+                logger.info("chat persona updated user_id=%s", chat_request.user_id)
+            except Exception as exc:
+                logger.warning("chat persona update failed user_id=%s error=%s", chat_request.user_id, exc)
+
+        asyncio.ensure_future(_update_persona())
+
+
+@router.post("/chat")
+async def chat(chat_request: ChatRequest, request: Request) -> StreamingResponse:
+    """Stream a styled fashion recommendation response via Server-Sent Events."""
+    logger.info("chat request user_id=%s message_preview=%s", chat_request.user_id, chat_request.message[:80])
+    return StreamingResponse(
+        _sse_stream(request, chat_request),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/src/stylemind/api/health.py
+++ b/src/stylemind/api/health.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request, status
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health(request: Request) -> JSONResponse:
+    """Return service health status, including Neo4j and embedder checks."""
+    neo4j_ok = False
+    embedder_ok = False
+
+    # Check Neo4j connectivity
+    neo4j_client = getattr(request.app.state, "neo4j", None)
+    if neo4j_client is not None:
+        try:
+            neo4j_ok = neo4j_client.verify_connectivity()
+        except Exception as exc:
+            logger.warning("health neo4j check failed error=%s", exc)
+            neo4j_ok = False
+
+    # Check embedder initialisation
+    embedder = getattr(request.app.state, "embedder", None)
+    if embedder is not None:
+        embedder_ok = True
+
+    healthy = neo4j_ok and embedder_ok
+    http_status = status.HTTP_200_OK if healthy else status.HTTP_503_SERVICE_UNAVAILABLE
+
+    payload = {"status": "ok" if healthy else "degraded", "neo4j": neo4j_ok, "embedder": embedder_ok}
+
+    logger.info("health check status=%s neo4j=%s embedder=%s", payload["status"], neo4j_ok, embedder_ok)
+    return JSONResponse(content=payload, status_code=http_status)

--- a/src/stylemind/api/persona.py
+++ b/src/stylemind/api/persona.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request
+
+from stylemind.models.schemas import PersonaSnapshot
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/persona/{user_id}", response_model=PersonaSnapshot)
+async def get_persona(user_id: str, request: Request) -> PersonaSnapshot:
+    """Return the current persona snapshot for a user.
+
+    Returns an empty default PersonaSnapshot when the user has no persona data yet.
+    """
+    persona_manager = getattr(request.app.state, "persona_manager", None)
+    if persona_manager is None:
+        logger.warning("persona get_persona persona_manager not initialised, returning default user_id=%s", user_id)
+        return PersonaSnapshot()
+
+    try:
+        snapshot = persona_manager.get_persona(user_id)
+        logger.info("persona get_persona user_id=%s confidence=%.2f", user_id, snapshot.confidence_score)
+        return snapshot
+    except Exception as exc:
+        logger.warning("persona get_persona failed user_id=%s error=%s, returning default", user_id, exc)
+        return PersonaSnapshot()

--- a/src/stylemind/cli/chat.py
+++ b/src/stylemind/cli/chat.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Generator
+from typing import Any
+
+import httpx
+from prompt_toolkit import prompt
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+logger = logging.getLogger(__name__)
+
+_WELCOME = """
+[bold cyan]StyleMind Fashion Assistant[/bold cyan]
+User ID: [bold]{user_id}[/bold]
+
+Commands:
+  [green]/persona[/green]  — show your current style persona
+  [green]quit[/green] / [green]exit[/green] — exit the chat
+
+Type your fashion question to get started!
+"""
+
+
+class ChatCLI:
+    def __init__(self, base_url: str, user_id: str, explain: bool = False) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.user_id = user_id
+        self.explain = explain
+        self.console = Console()
+        self._history: list[dict[str, str]] = []
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        self.console.print(_WELCOME.format(user_id=self.user_id))
+        while True:
+            try:
+                user_input = prompt("You: ").strip()
+            except EOFError, KeyboardInterrupt:
+                self.console.print("\n[dim]Goodbye![/dim]")
+                break
+
+            if not user_input:
+                continue
+
+            if user_input.lower() in {"quit", "exit"}:
+                self.console.print("[dim]Goodbye![/dim]")
+                break
+
+            if user_input.lower() == "/persona":
+                self._show_persona()
+                continue
+
+            self._send_message(user_input)
+
+    # ------------------------------------------------------------------
+    # SSE streaming
+    # ------------------------------------------------------------------
+
+    def _send_message(self, message: str) -> None:
+        payload: dict[str, Any] = {
+            "user_id": self.user_id,
+            "message": message,
+            "history": self._history,
+            "explain": self.explain,
+        }
+
+        self.console.print()
+        self.console.print("[bold green]StyleMind:[/bold green]", end=" ")
+
+        full_text = ""
+        try:
+            with (
+                httpx.Client(timeout=60.0) as client,
+                client.stream("POST", f"{self.base_url}/chat", json=payload) as response,
+            ):
+                response.raise_for_status()
+                for chunk in self._parse_sse_stream(response):
+                    if chunk.startswith("__JSON__"):
+                        # structured response payload
+                        self._handle_structured(chunk[8:])
+                    else:
+                        self.console.print(chunk, end="", highlight=False)
+                        full_text += chunk
+        except httpx.HTTPStatusError as exc:
+            self.console.print(f"[red]HTTP error {exc.response.status_code}[/red]")
+            return
+        except httpx.RequestError as exc:
+            self.console.print(f"[red]Connection error: {exc}[/red]")
+            return
+
+        self.console.print()  # newline after streamed response
+
+        # Update conversation history
+        self._history.append({"role": "user", "content": message})
+        self._history.append({"role": "assistant", "content": full_text})
+
+    def _parse_sse_stream(self, response: httpx.Response) -> Generator[str]:
+        """Parse SSE data lines from a streaming httpx response."""
+        for line in response.iter_lines():
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("data: "):
+                data = line[6:]
+                if data == "[DONE]":
+                    break
+                yield data
+
+    # ------------------------------------------------------------------
+    # Structured payload handling (products / outfit)
+    # ------------------------------------------------------------------
+
+    def _handle_structured(self, json_str: str) -> None:
+        """Render product citations and outfit suggestions if present."""
+        try:
+            payload = json.loads(json_str)
+        except json.JSONDecodeError:
+            logger.warning("Could not decode structured payload")
+            return
+
+        sources: list[dict[str, Any]] = payload.get("sources", [])
+        outfit: dict[str, Any] | None = payload.get("outfit")
+
+        if sources:
+            self._render_sources(sources)
+
+        if outfit:
+            self._render_outfit(outfit)
+
+    def _render_sources(self, sources: list[dict[str, Any]]) -> None:
+        content_lines = []
+        for s in sources:
+            name = s.get("name", "Unknown")
+            brand = s.get("brand", "")
+            price = s.get("price_inr", 0)
+            score = s.get("score", 0.0)
+            content_lines.append(f"• [bold]{name}[/bold] by {brand} — ₹{price:,}  (score: {score:.2f})")
+
+        panel = Panel(
+            "\n".join(content_lines),
+            title="[bold blue]Product Citations[/bold blue]",
+            expand=False,
+        )
+        self.console.print(panel)
+
+    def _render_outfit(self, outfit: dict[str, Any]) -> None:
+        table = Table(
+            title=f"Outfit Suggestion — {outfit.get('occasion', '')} / {outfit.get('season', '')}",
+            show_header=True,
+            header_style="bold magenta",
+        )
+        table.add_column("Item", style="bold")
+        table.add_column("Category")
+        table.add_column("Brand")
+        table.add_column("Price (₹)", justify="right")
+        table.add_column("Justification")
+
+        anchor = outfit.get("anchor", {})
+        if anchor:
+            table.add_row(
+                anchor.get("name", ""),
+                anchor.get("category", ""),
+                anchor.get("brand", ""),
+                f"₹{anchor.get('price_inr', 0):,}",
+                "[dim]anchor[/dim]",
+            )
+
+        for item in outfit.get("items", []):
+            table.add_row(
+                item.get("name", ""),
+                item.get("category", ""),
+                item.get("brand", ""),
+                f"₹{item.get('price_inr', 0):,}",
+                item.get("justification", ""),
+            )
+
+        self.console.print(table)
+
+    # ------------------------------------------------------------------
+    # Persona display
+    # ------------------------------------------------------------------
+
+    def _show_persona(self) -> None:
+        try:
+            with httpx.Client(timeout=10.0) as client:
+                resp = client.get(f"{self.base_url}/persona/{self.user_id}")
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPStatusError as exc:
+            self.console.print(f"[red]HTTP error {exc.response.status_code}[/red]")
+            return
+        except httpx.RequestError as exc:
+            self.console.print(f"[red]Connection error: {exc}[/red]")
+            return
+
+        aesthetics = ", ".join(data.get("preferred_aesthetics", [])) or "[dim]none yet[/dim]"
+        disliked = ", ".join(data.get("disliked_materials", [])) or "[dim]none[/dim]"
+        budget = data.get("budget_tier") or "[dim]unknown[/dim]"
+        occasions = ", ".join(data.get("top_occasions", [])) or "[dim]none yet[/dim]"
+        confidence = data.get("confidence_score", 0.0)
+
+        lines = [
+            f"[green]Aesthetics:[/green]       {aesthetics}",
+            f"[red]Disliked materials:[/red] {disliked}",
+            f"[yellow]Budget tier:[/yellow]      {budget}",
+            f"[blue]Occasions:[/blue]        {occasions}",
+            f"[magenta]Confidence:[/magenta]       {confidence:.2f}",
+        ]
+
+        panel = Panel(
+            "\n".join(lines),
+            title="[bold]Your Style Persona[/bold]",
+            expand=False,
+        )
+        self.console.print(panel)

--- a/src/stylemind/main.py
+++ b/src/stylemind/main.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+
+from stylemind.api import chat as chat_router
+from stylemind.api import health as health_router
+from stylemind.api import persona as persona_router
+from stylemind.config import get_config
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """Application lifespan: startup and shutdown lifecycle."""
+    config = get_config()
+    logging.basicConfig(level=config.settings.log_level)
+
+    # --- Startup ---
+
+    # 1. Neo4j client
+    from stylemind.graph.client import Neo4jClient
+
+    neo4j_client = Neo4jClient(config.neo4j)
+    neo4j_client.connect()
+    app.state.neo4j = neo4j_client
+    logger.info("lifespan neo4j connected uri=%s", config.neo4j.uri)
+
+    # 2. Embedder
+    from stylemind.rag.embedder import LocalEmbedder
+
+    embedder = LocalEmbedder(model_name=config.embedding.model_name)
+    app.state.embedder = embedder
+    logger.info("lifespan embedder initialised model=%s", config.embedding.model_name)
+
+    # 3. ProductRetriever
+    from stylemind.rag.retriever import ProductRetriever
+
+    retriever = ProductRetriever(
+        client=neo4j_client,
+        embedder=embedder,
+        top_k=config.settings.vector_top_k,
+        min_threshold=config.settings.min_similarity_threshold,
+    )
+    app.state.retriever = retriever
+
+    # 4. PersonaAwareReranker
+    from stylemind.rag.reranker import ProductReranker
+
+    reranker = ProductReranker()
+    app.state.reranker = reranker
+
+    # 5. StyleMindGenerator (chat LLM)
+    from stylemind.rag.generator import StyleMindGenerator
+
+    generator = StyleMindGenerator(config.chat_llm)
+    app.state.generator = generator
+
+    # 6. PersonaManager
+    from stylemind.persona.manager import PersonaManager
+
+    persona_manager = PersonaManager(
+        driver=neo4j_client.driver,
+        decay_rate=config.settings.persona_decay_rate,
+        expected_signals_per_turn=config.settings.expected_signals_per_turn,
+    )
+    app.state.persona_manager = persona_manager
+
+    # 7. PersonaInferenceEngine (extraction LLM)
+    from stylemind.persona.inference import PersonaInferenceEngine
+
+    inference_engine = PersonaInferenceEngine(config.extraction_llm)
+    app.state.inference_engine = inference_engine
+
+    # 8. OutfitBuilder
+    from stylemind.outfit.builder import OutfitBuilder
+
+    outfit_builder = OutfitBuilder(driver=neo4j_client.driver)
+    app.state.outfit_builder = outfit_builder
+
+    logger.info("lifespan startup complete")
+
+    yield
+
+    # --- Shutdown ---
+    neo4j_client.close()
+    logger.info("lifespan shutdown complete")
+
+
+def create_app() -> FastAPI:
+    """Factory function: creates and configures the FastAPI application."""
+    app = FastAPI(
+        title="StyleMind",
+        description="RAG-powered fashion styling assistant with Neo4j knowledge graph",
+        version="0.1.0",
+        docs_url="/docs",
+        redoc_url="/redoc",
+        lifespan=lifespan,
+    )
+
+    # CORS (permissive for dev; tighten in prod via env)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # Request-ID logging middleware
+    @app.middleware("http")
+    async def request_logging_middleware(request: Request, call_next: object) -> Response:
+        request_id = str(uuid.uuid4())
+        start = time.monotonic()
+        logger.info(
+            "request started request_id=%s method=%s path=%s",
+            request_id,
+            request.method,
+            request.url.path,
+        )
+        response: Response = await call_next(request)  # type: ignore[operator]
+        elapsed_ms = (time.monotonic() - start) * 1000
+        logger.info(
+            "request finished request_id=%s status=%d duration_ms=%.1f",
+            request_id,
+            response.status_code,
+            elapsed_ms,
+        )
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+    # Routers
+    app.include_router(chat_router.router)
+    app.include_router(persona_router.router)
+    app.include_router(health_router.router)
+
+    return app
+
+
+# Module-level app instance for uvicorn / __main__
+app = create_app()

--- a/src/stylemind/rag/generator.py
+++ b/src/stylemind/rag/generator.py
@@ -62,9 +62,7 @@ def _format_outfit_context(outfit: OutfitSuggestion) -> str:
         f"  Anchor: {outfit.anchor.name} by {outfit.anchor.brand} — ₹{outfit.anchor.price_inr:,}",
     ]
     for item in outfit.items:
-        lines.append(
-            f"  + {item.name} by {item.brand} — ₹{item.price_inr:,} ({item.category}): {item.justification}"
-        )
+        lines.append(f"  + {item.name} by {item.brand} — ₹{item.price_inr:,} ({item.category}): {item.justification}")
     return "\n".join(lines)
 
 

--- a/src/stylemind/rag/generator.py
+++ b/src/stylemind/rag/generator.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
+
+from openai import AsyncOpenAI
+
+from stylemind.config import ChatLLMConfig
+from stylemind.models.domain import RetrievedProduct
+
+if TYPE_CHECKING:
+    from stylemind.models.schemas import OutfitSuggestion
+
+logger = logging.getLogger(__name__)
+
+_INTEREST_PHRASES = (
+    "like",
+    "love",
+    "interested in",
+    "want",
+    "show me more",
+    "tell me about",
+    "that one",
+    "this one",
+    "similar to",
+)
+
+_SYSTEM_PROMPT = """You are StyleMind, a friendly and knowledgeable personal stylist assistant.
+
+Guidelines:
+- Only recommend products from the provided context. NEVER invent or hallucinate products.
+- When mentioning a product, always include its exact name, brand, and price (in INR).
+- NEVER ask the user directly about their style preferences, size, or budget — infer from context.
+- When suggesting outfit pairings, explain why each item complements the others (occasion, aesthetic, season).
+- Be honest and helpful when no products match the user's request.
+- Keep responses concise, warm, and actionable.
+- Format prices as ₹X,XXX (e.g., ₹2,500).
+"""
+
+
+def _format_product_context(products: list[RetrievedProduct]) -> str:
+    """Format retrieved products as a numbered list for the LLM context."""
+    if not products:
+        return "No products available in the current context."
+
+    lines: list[str] = ["Available products:"]
+    for i, product in enumerate(products, start=1):
+        aesthetics = ", ".join(product.aesthetics) if product.aesthetics else "N/A"
+        occasions = ", ".join(product.occasions) if product.occasions else "N/A"
+        lines.append(
+            f"{i}. {product.name} | Brand: {product.brand} | Price: ₹{product.price:,} "
+            f"| Category: {product.category} | Aesthetics: {aesthetics} | Occasions: {occasions}"
+        )
+    return "\n".join(lines)
+
+
+def _format_outfit_context(outfit: OutfitSuggestion) -> str:
+    """Format an outfit suggestion for the LLM context."""
+    lines: list[str] = [
+        f"\nSuggested outfit for {outfit.occasion} ({outfit.season}):",
+        f"  Anchor: {outfit.anchor.name} by {outfit.anchor.brand} — ₹{outfit.anchor.price_inr:,}",
+    ]
+    for item in outfit.items:
+        lines.append(
+            f"  + {item.name} by {item.brand} — ₹{item.price_inr:,} ({item.category}): {item.justification}"
+        )
+    return "\n".join(lines)
+
+
+class StyleMindGenerator:
+    """LLM response generator with streaming support and citation grounding."""
+
+    def __init__(self, config: ChatLLMConfig) -> None:
+        self._config = config
+        self._client = AsyncOpenAI(base_url=config.base_url, api_key=config.api_key)
+
+    async def stream_response(
+        self,
+        message: str,
+        history: list[dict[str, str]],
+        retrieved_products: list[RetrievedProduct],
+        outfit: OutfitSuggestion | None = None,
+    ) -> AsyncGenerator[str]:
+        """Stream an LLM response grounded in the retrieved products.
+
+        Args:
+            message: Current user message.
+            history: Prior conversation turns as list of {"role": ..., "content": ...} dicts.
+            retrieved_products: Products from the RAG retriever/reranker.
+            outfit: Optional outfit suggestion from the outfit builder.
+
+        Yields:
+            Text chunks as they arrive from the LLM stream.
+        """
+        product_context = _format_product_context(retrieved_products)
+        context_block = product_context
+        if outfit is not None:
+            context_block += "\n" + _format_outfit_context(outfit)
+
+        # Build message list: system + history + context-injected user message
+        messages: list[dict[str, str]] = [{"role": "system", "content": _SYSTEM_PROMPT}]
+        messages.extend(history)
+        messages.append(
+            {
+                "role": "user",
+                "content": f"{context_block}\n\nUser: {message}",
+            }
+        )
+
+        logger.info(
+            "generator stream_response product_count=%d has_outfit=%s model=%s",
+            len(retrieved_products),
+            outfit is not None,
+            self._config.model,
+        )
+
+        stream = await self._client.chat.completions.create(
+            model=self._config.model,
+            messages=messages,  # type: ignore[arg-type]
+            temperature=self._config.temperature,
+            stream=True,
+        )
+
+        async for chunk in stream:
+            delta = chunk.choices[0].delta.content if chunk.choices else None
+            if delta:
+                yield delta
+
+    def detect_product_interest(
+        self,
+        message: str,
+        products: list[RetrievedProduct],
+    ) -> str | None:
+        """Detect whether the user is expressing interest in a specific product.
+
+        Uses simple keyword matching against product names and IDs — no LLM call.
+
+        Args:
+            message: Raw user message text.
+            products: Products currently in context.
+
+        Returns:
+            product_id of the matched product, or None if no interest detected.
+        """
+        if not products:
+            return None
+
+        message_lower = message.lower()
+
+        # Check if message contains any interest phrase
+        has_interest_phrase = any(phrase in message_lower for phrase in _INTEREST_PHRASES)
+        if not has_interest_phrase:
+            return None
+
+        # Match against product names (longest match first to avoid partial collisions)
+        sorted_products = sorted(products, key=lambda p: len(p.name), reverse=True)
+        for product in sorted_products:
+            if product.name.lower() in message_lower:
+                logger.debug(
+                    "generator detect_product_interest matched product_id=%s name=%s",
+                    product.product_id,
+                    product.name,
+                )
+                return product.product_id
+
+        # Fall back to product_id mention
+        for product in products:
+            if product.product_id.lower() in message_lower:
+                logger.debug(
+                    "generator detect_product_interest matched product_id=%s via id",
+                    product.product_id,
+                )
+                return product.product_id
+
+        return None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stylemind.models.schemas import PersonaSnapshot
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_app_with_mocks(
+    neo4j_ok: bool = True,
+    embedder_ok: bool = True,
+    persona: PersonaSnapshot | None = None,
+    stream_chunks: list[str] | None = None,
+) -> FastAPI:
+    """Build a FastAPI test app with all dependencies pre-populated on app.state."""
+    from fastapi import FastAPI
+
+    test_app = FastAPI()
+
+    # Register routers directly (no lifespan needed)
+    from stylemind.api import chat as chat_module
+    from stylemind.api import health as health_module
+    from stylemind.api import persona as persona_module
+
+    test_app.include_router(chat_module.router)
+    test_app.include_router(persona_module.router)
+    test_app.include_router(health_module.router)
+
+    # --- Neo4j mock ---
+    if neo4j_ok:
+        mock_neo4j = MagicMock()
+        mock_neo4j.verify_connectivity = MagicMock(return_value=True)
+        test_app.state.neo4j = mock_neo4j
+    # If neo4j_ok is False, don't set state.neo4j so health check sees None
+
+    # --- Embedder mock ---
+    if embedder_ok:
+        mock_embedder = MagicMock()
+        mock_embedder.embed_query = MagicMock(return_value=[0.0] * 384)
+        test_app.state.embedder = mock_embedder
+    # If embedder_ok is False, don't set state.embedder
+
+    # --- Persona manager mock ---
+    mock_persona_manager = MagicMock()
+    resolved_persona = persona if persona is not None else PersonaSnapshot()
+    mock_persona_manager.get_persona = MagicMock(return_value=resolved_persona)
+    mock_persona_manager.update_persona = MagicMock()
+    test_app.state.persona_manager = mock_persona_manager
+
+    # --- PersonaInferenceEngine mock ---
+    mock_inference = MagicMock()
+    from stylemind.models.schemas import PersonaSignals
+
+    mock_inference.extract_signals = MagicMock(return_value=PersonaSignals())
+    test_app.state.inference_engine = mock_inference
+
+    # --- Retriever mock ---
+    mock_retriever = MagicMock()
+    mock_retriever.retrieve = MagicMock(return_value=[])
+    test_app.state.retriever = mock_retriever
+
+    # --- Reranker mock ---
+    mock_reranker = MagicMock()
+    mock_reranker.rerank = MagicMock(return_value=[])
+    test_app.state.reranker = mock_reranker
+
+    # --- Generator mock ---
+    chunks = stream_chunks if stream_chunks is not None else ["Hello", " world"]
+
+    async def _fake_stream(*args, **kwargs):
+        for chunk in chunks:
+            yield chunk
+
+    mock_generator = MagicMock()
+    mock_generator.stream_response = MagicMock(side_effect=_fake_stream)
+    mock_generator.detect_product_interest = MagicMock(return_value=None)
+    test_app.state.generator = mock_generator
+
+    # --- OutfitBuilder mock ---
+    mock_outfit = MagicMock()
+    mock_outfit.build_outfit = MagicMock(return_value=None)
+    test_app.state.outfit_builder = mock_outfit
+
+    return test_app
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_chat_sse_stream():
+    """POST /chat returns SSE stream with data: chunks and a final [DONE]."""
+    app = _make_app_with_mocks(stream_chunks=["Style", " tip"])
+    client = TestClient(app, raise_server_exceptions=True)
+
+    payload = {"user_id": "user-1", "message": "What should I wear?"}
+    response = client.post("/chat", json=payload)
+
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers["content-type"]
+
+    # Collect all SSE lines
+    sse_lines = [line for line in response.text.splitlines() if line.startswith("data:")]
+    assert len(sse_lines) >= 1
+
+    # Final chunk must be [DONE]
+    assert sse_lines[-1] == "data: [DONE]"
+
+    # Content chunks should include our fake stream output
+    content_chunks = [line[len("data: ") :] for line in sse_lines if line != "data: [DONE]"]
+    assert "Style" in content_chunks or "Style" in "".join(content_chunks)
+
+
+@pytest.mark.integration
+def test_persona_endpoint_returns_snapshot():
+    """GET /persona/{user_id} returns a valid PersonaSnapshot JSON."""
+    snapshot = PersonaSnapshot(
+        preferred_aesthetics=["Quiet Luxury", "Old Money"],
+        disliked_materials=["Polyester"],
+        budget_tier="premium",
+        top_occasions=["Office"],
+        confidence_score=0.75,
+    )
+    app = _make_app_with_mocks(persona=snapshot)
+    client = TestClient(app, raise_server_exceptions=True)
+
+    response = client.get("/persona/user-1")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["preferred_aesthetics"] == ["Quiet Luxury", "Old Money"]
+    assert data["disliked_materials"] == ["Polyester"]
+    assert data["budget_tier"] == "premium"
+    assert data["top_occasions"] == ["Office"]
+    assert data["confidence_score"] == pytest.approx(0.75)
+
+
+@pytest.mark.integration
+def test_health_returns_200_when_healthy():
+    """GET /health returns 200 when Neo4j is connected and embedder is loaded."""
+    app = _make_app_with_mocks(neo4j_ok=True, embedder_ok=True)
+    client = TestClient(app, raise_server_exceptions=True)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["neo4j"] is True
+    assert data["embedder"] is True
+
+
+@pytest.mark.integration
+def test_health_returns_503_when_neo4j_unavailable():
+    """GET /health returns 503 when Neo4j is not available."""
+    app = _make_app_with_mocks(neo4j_ok=False, embedder_ok=True)
+    client = TestClient(app, raise_server_exceptions=True)
+
+    response = client.get("/health")
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["neo4j"] is False
+
+
+# ---------------------------------------------------------------------------
+# Contract / schema tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_persona_snapshot_validates_against_spec():
+    """PersonaSnapshot validates all required spec fields with correct types."""
+    snapshot = PersonaSnapshot(
+        preferred_aesthetics=["Streetwear"],
+        disliked_materials=["Nylon"],
+        budget_tier="mid",
+        top_occasions=["Casual", "Active"],
+        confidence_score=0.5,
+    )
+
+    assert isinstance(snapshot.preferred_aesthetics, list)
+    assert isinstance(snapshot.disliked_materials, list)
+    assert isinstance(snapshot.budget_tier, str)
+    assert isinstance(snapshot.top_occasions, list)
+    assert isinstance(snapshot.confidence_score, float)
+
+    # Default empty state must also be valid
+    empty = PersonaSnapshot()
+    assert empty.preferred_aesthetics == []
+    assert empty.disliked_materials == []
+    assert empty.budget_tier is None
+    assert empty.top_occasions == []
+    assert empty.confidence_score == 0.0
+
+
+@pytest.mark.unit
+def test_persona_endpoint_returns_default_when_no_data():
+    """GET /persona/{user_id} returns empty PersonaSnapshot for unknown user."""
+    app = _make_app_with_mocks(persona=PersonaSnapshot())
+    client = TestClient(app, raise_server_exceptions=True)
+
+    response = client.get("/persona/unknown-user-xyz")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["preferred_aesthetics"] == []
+    assert data["confidence_score"] == 0.0
+    assert data["budget_tier"] is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from stylemind.cli.chat import ChatCLI
+
+# ---------------------------------------------------------------------------
+# Unit tests — SSE parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestParseSseStream:
+    def _cli(self) -> ChatCLI:
+        return ChatCLI(base_url="http://localhost:8000", user_id="test1234")
+
+    def _make_response(self, lines: list[str]) -> MagicMock:
+        mock = MagicMock()
+        mock.iter_lines.return_value = iter(lines)
+        return mock
+
+    def test_single_chunk(self) -> None:
+        cli = self._cli()
+        response = self._make_response(["data: hello world"])
+        result = list(cli._parse_sse_stream(response))
+        assert result == ["hello world"]
+
+    def test_multiple_chunks(self) -> None:
+        cli = self._cli()
+        response = self._make_response(["data: chunk one", "data: chunk two", "data: chunk three"])
+        result = list(cli._parse_sse_stream(response))
+        assert result == ["chunk one", "chunk two", "chunk three"]
+
+    def test_done_terminates_stream(self) -> None:
+        cli = self._cli()
+        response = self._make_response(["data: hello", "data: [DONE]", "data: should not appear"])
+        result = list(cli._parse_sse_stream(response))
+        assert result == ["hello"]
+
+    def test_empty_lines_skipped(self) -> None:
+        cli = self._cli()
+        response = self._make_response(["", "data: hello", "", "data: world", ""])
+        result = list(cli._parse_sse_stream(response))
+        assert result == ["hello", "world"]
+
+    def test_non_data_lines_skipped(self) -> None:
+        cli = self._cli()
+        response = self._make_response(
+            [
+                "event: message",
+                "id: 1",
+                "data: actual content",
+                ": keep-alive comment",
+            ]
+        )
+        result = list(cli._parse_sse_stream(response))
+        assert result == ["actual content"]
+
+    def test_empty_stream(self) -> None:
+        cli = self._cli()
+        response = self._make_response([])
+        result = list(cli._parse_sse_stream(response))
+        assert result == []
+
+    def test_only_done(self) -> None:
+        cli = self._cli()
+        response = self._make_response(["data: [DONE]"])
+        result = list(cli._parse_sse_stream(response))
+        assert result == []
+
+    def test_whitespace_trimmed_from_lines(self) -> None:
+        cli = self._cli()
+        response = self._make_response(["  data: trimmed  ", "data: normal"])
+        result = list(cli._parse_sse_stream(response))
+        # Lines are fully stripped so "  data: trimmed  " -> "data: trimmed" -> data="trimmed"
+        assert result == ["trimmed", "normal"]
+
+    def test_data_with_json_content(self) -> None:
+        cli = self._cli()
+        response = self._make_response(['data: {"key": "value"}'])
+        result = list(cli._parse_sse_stream(response))
+        assert result == ['{"key": "value"}']
+
+
+# ---------------------------------------------------------------------------
+# E2E smoke test — requires a running server
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestCliSmoke:
+    def test_server_health(self) -> None:
+        """Verify the server is running and healthy."""
+        import httpx
+
+        try:
+            resp = httpx.get("http://localhost:8000/health", timeout=3.0)
+        except httpx.ConnectError:
+            pytest.skip("No server running at localhost:8000")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data.get("status") == "ok"
+
+    def test_send_message_streams(self) -> None:
+        """Send one message, confirm SSE chunks arrive."""
+        import httpx
+
+        payload = {
+            "user_id": "smoke001",
+            "message": "Suggest a casual outfit for a weekend brunch.",
+            "history": [],
+            "explain": False,
+        }
+
+        try:
+            with (
+                httpx.Client(timeout=30.0) as client,
+                client.stream("POST", "http://localhost:8000/chat", json=payload) as response,
+            ):
+                if response.status_code != 200:
+                    pytest.skip(f"Server returned {response.status_code}")
+                chunks = []
+                for line in response.iter_lines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    if line.startswith("data: "):
+                        data = line[6:]
+                        if data == "[DONE]":
+                            break
+                        chunks.append(data)
+        except httpx.ConnectError:
+            pytest.skip("No server running at localhost:8000")
+
+        assert len(chunks) > 0, "Expected at least one SSE chunk"
+
+    def test_persona_endpoint(self) -> None:
+        """Verify /persona/{user_id} returns a valid snapshot."""
+        import httpx
+
+        try:
+            resp = httpx.get("http://localhost:8000/persona/smoke001", timeout=5.0)
+        except httpx.ConnectError:
+            pytest.skip("No server running at localhost:8000")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "preferred_aesthetics" in data
+        assert "confidence_score" in data

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from stylemind.models.domain import RetrievedProduct
+from stylemind.rag.generator import StyleMindGenerator, _format_product_context
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_product(
+    product_id: str = "P001",
+    name: str = "Classic White Shirt",
+    brand: str = "Uniqlo",
+    price: int = 2499,
+    category: str = "Top",
+    aesthetics: list[str] | None = None,
+    occasions: list[str] | None = None,
+) -> RetrievedProduct:
+    return RetrievedProduct(
+        product_id=product_id,
+        name=name,
+        description="A versatile white shirt",
+        price=price,
+        category=category,
+        brand=brand,
+        budget_tier="Mid",
+        aesthetics=aesthetics or ["Minimalist"],
+        occasions=occasions or ["Office", "Casual"],
+        colors=["White"],
+        seasons=["Year-round"],
+        pairs_with=[],
+        similarity_score=0.85,
+    )
+
+
+def make_generator() -> StyleMindGenerator:
+    from stylemind.config import ChatLLMConfig
+
+    config = ChatLLMConfig(
+        base_url="https://api.groq.com/openai/v1",
+        api_key="test-key",
+        model="llama-3.3-70b-versatile",
+        temperature=0.7,
+    )
+    return StyleMindGenerator(config=config)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_format_product_context_numbered_list() -> None:
+    """Context formatting should produce a numbered list with name, brand, price, aesthetics, occasions."""
+    products = [
+        make_product("P001", "Classic White Shirt", "Uniqlo", 2499, aesthetics=["Minimalist"], occasions=["Office"]),
+        make_product("P002", "Floral Sundress", "Zara", 3999, aesthetics=["Boho"], occasions=["Casual", "Beach"]),
+    ]
+
+    context = _format_product_context(products)
+
+    # Check numbered list structure
+    assert "1." in context
+    assert "2." in context
+
+    # Check product 1 fields
+    assert "Classic White Shirt" in context
+    assert "Uniqlo" in context
+    assert "2,499" in context
+    assert "Minimalist" in context
+    assert "Office" in context
+
+    # Check product 2 fields
+    assert "Floral Sundress" in context
+    assert "Zara" in context
+    assert "3,999" in context
+    assert "Boho" in context
+    assert "Beach" in context
+
+
+@pytest.mark.unit
+def test_format_product_context_empty_list() -> None:
+    """Empty product list should return a 'no products' message."""
+    context = _format_product_context([])
+    assert "No products" in context
+
+
+@pytest.mark.unit
+def test_detect_product_interest_catches_interest_phrases() -> None:
+    """detect_product_interest should return product_id when user expresses interest in a named product."""
+    generator = make_generator()
+    products = [
+        make_product("P001", "Classic White Shirt"),
+        make_product("P002", "Floral Sundress"),
+    ]
+
+    # Various interest phrases paired with a product name
+    test_cases = [
+        ("I love the Classic White Shirt", "P001"),
+        ("I like Floral Sundress, can you show me more?", "P002"),
+        ("I'm interested in Classic White Shirt", "P001"),
+        ("I want the Floral Sundress", "P002"),
+        ("Tell me about Classic White Shirt", "P001"),
+        ("Show me more like Floral Sundress", "P002"),
+        ("I want something similar to Classic White Shirt", "P001"),
+    ]
+
+    for message, expected_id in test_cases:
+        result = generator.detect_product_interest(message, products)
+        assert result == expected_id, f"Expected {expected_id!r} for message {message!r}, got {result!r}"
+
+
+@pytest.mark.unit
+def test_detect_product_interest_returns_none_for_generic_messages() -> None:
+    """detect_product_interest should return None for generic messages without product references."""
+    generator = make_generator()
+    products = [
+        make_product("P001", "Classic White Shirt"),
+        make_product("P002", "Floral Sundress"),
+    ]
+
+    generic_messages = [
+        "What's trending this season?",
+        "Show me something for a beach vacation",
+        "I need an outfit for a wedding",
+        "What do you recommend?",
+        "Hello!",
+    ]
+
+    for message in generic_messages:
+        result = generator.detect_product_interest(message, products)
+        assert result is None, f"Expected None for message {message!r}, got {result!r}"
+
+
+@pytest.mark.unit
+def test_detect_product_interest_returns_none_when_no_products() -> None:
+    """detect_product_interest should return None when the product list is empty."""
+    generator = make_generator()
+    result = generator.detect_product_interest("I love the Classic White Shirt", [])
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — mock LLM client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_stream_response_yields_chunks() -> None:
+    """stream_response should yield text chunks from the LLM stream."""
+    from stylemind.config import ChatLLMConfig
+
+    config = ChatLLMConfig(
+        base_url="https://api.groq.com/openai/v1",
+        api_key="test-key",
+        model="llama-3.3-70b-versatile",
+        temperature=0.7,
+    )
+
+    products = [
+        make_product("P001", "Classic White Shirt", "Uniqlo", 2499),
+    ]
+
+    # Build mock chunks mimicking the OpenAI streaming response
+    def make_chunk(content: str) -> MagicMock:
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta.content = content
+        return chunk
+
+    expected_chunks = ["Here ", "is ", "a ", "recommendation."]
+    mock_stream = AsyncMock()
+    mock_stream.__aiter__ = AsyncMock(return_value=iter([make_chunk(c) for c in expected_chunks]))
+
+    # Make the async context manager return our mock stream
+    async def fake_aiter(self: object) -> AsyncIterator[MagicMock]:
+        for chunk in [make_chunk(c) for c in expected_chunks]:
+            yield chunk
+
+    mock_stream.__aiter__ = fake_aiter
+
+    mock_completions = AsyncMock()
+    mock_completions.create = AsyncMock(return_value=mock_stream)
+
+    mock_chat = MagicMock()
+    mock_chat.completions = mock_completions
+
+    with patch("stylemind.rag.generator.AsyncOpenAI") as mock_openai_cls:
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat = mock_chat
+        mock_openai_cls.return_value = mock_client_instance
+
+        generator = StyleMindGenerator(config=config)
+
+        collected: list[str] = []
+        async for chunk in generator.stream_response(
+            message="What shirts do you recommend?",
+            history=[],
+            retrieved_products=products,
+            outfit=None,
+        ):
+            collected.append(chunk)
+
+    assert collected == expected_chunks, f"Expected {expected_chunks!r}, got {collected!r}"
+    assert len(collected) == 4

--- a/uv.lock
+++ b/uv.lock
@@ -379,21 +379,22 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.36.2"
+version = "1.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "tqdm" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/9f/3fda8b014db3ae239addc9b48b35c2cf7d318950b430712f34a2473ef81d/huggingface_hub-1.12.2.tar.gz", hash = "sha256:282c4999e641c89affdc4c02c265eddea944c1390dc19e89dac8ad3ae76dbdaf", size = 763393, upload-time = "2026-04-29T09:45:09.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c1/1fa4162f6dd53259daf2ad31385273341821fa0acce164cd03971937a60e/huggingface_hub-1.12.2-py3-none-any.whl", hash = "sha256:7968e897fdbc6343c871c240d87d4434efe0ad9f80d57daa1cc5678c6d148529", size = 647757, upload-time = "2026-04-29T09:45:07.63Z" },
 ]
 
 [[package]]
@@ -1489,6 +1490,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1548,6 +1558,7 @@ dependencies = [
     { name = "rich" },
     { name = "sentence-transformers" },
     { name = "sse-starlette" },
+    { name = "transformers" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1575,6 +1586,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0" },
     { name = "sentence-transformers", specifier = ">=5.0" },
     { name = "sse-starlette", specifier = ">=2.0" },
+    { name = "transformers", specifier = ">=5.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
 
@@ -1725,23 +1737,22 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.57.6"
+version = "5.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
-    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/fe/7e84d20ac7d4d5d14bac2eab5976088d86342959fc2c0da54b4c2fc99856/transformers-5.7.0.tar.gz", hash = "sha256:a9d35cf39804e3456c1f9bc1a79ad5ffa878640a61f51f66f71c97f4b4e2ce10", size = 8401287, upload-time = "2026-04-28T18:30:09.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
+    { url = "https://files.pythonhosted.org/packages/60/60/86a9fe3037bec221094e2acb680219ad88b77006edba42fc0407a577ca93/transformers-5.7.0-py3-none-any.whl", hash = "sha256:869660cd8fc92badc041f5551bf755a42f4b9558c93341bf3fa3eeed7065079c", size = 10474236, upload-time = "2026-04-28T18:30:05.655Z" },
 ]
 
 [[package]]
@@ -1753,6 +1764,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
     { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issues Closed
- Closes #11 — RAG generator: LLM prompt construction, streaming, citation grounding
- Closes #12 — FastAPI app: /chat SSE, /persona JSON, /health endpoints
- Closes #13 — Rich CLI: embedded server, chat loop, streaming display

## Overview

### Before (wave-2 baseline)
Wave 2 delivered the retrieval, persona, and outfit building intelligence. The system could retrieve and rerank products, infer persona signals, and compose outfits — but had no HTTP API, no streaming LLM responses, and no way to interact with it directly.

### After (wave-3)
The full application stack is now runnable end-to-end with a single command: `uv run python -m stylemind`.

| Component | File | What it does |
|---|---|---|
| RAG Generator | `src/stylemind/rag/generator.py` | `StyleMindGenerator` streams Groq/Llama-3.3-70B responses via OpenAI-compatible SDK. Formats retrieved products as a numbered context block (name, brand, price, aesthetics, occasions). `detect_product_interest()` does keyword matching against product names to trigger outfit building without an extra LLM call. |
| FastAPI App | `src/stylemind/main.py` | `create_app()` factory with lifespan that connects Neo4j, loads embedder, and wires all components onto `app.state`. UUID4 request-ID middleware for structured logging. |
| /chat endpoint | `src/stylemind/api/chat.py` | `POST /chat` → `StreamingResponse(media_type="text/event-stream")`. Full pipeline: get_persona → retrieve → rerank → detect_interest → build_outfit (conditional) → stream_response. Persona update is fire-and-forget via `asyncio.ensure_future` — zero impact on streaming latency. Each chunk: `data: <text>\n\n`; terminal: `data: [DONE]\n\n`. |
| /persona endpoint | `src/stylemind/api/persona.py` | `GET /persona/{user_id}` returns spec-compliant `PersonaSnapshot` JSON. Falls back to empty default if user unknown — never 404. |
| /health endpoint | `src/stylemind/api/health.py` | `GET /health` checks Neo4j connectivity and embedder presence. HTTP 200 when healthy, 503 otherwise. |
| Rich CLI | `src/stylemind/cli/chat.py` | `ChatCLI` uses `httpx.stream()` for SSE parsing, `rich.console.Console` for rendering (Markdown for text, Panel for citations, Table for outfit suggestions). `/persona` command shows current persona state. |
| CLI entry point | `src/stylemind/__main__.py` | Starts uvicorn in a daemon thread, polls `/health` with 500ms intervals (30s timeout), generates 8-char hex `user_id`, then enters `ChatCLI.run()`. `Ctrl+C` handled gracefully. |

## Test Results

```
109 passed, 5 skipped (integration tests — Neo4j not running locally)
0 ruff errors
0 pyright errors
No known vulnerabilities found (CVE-2026-1839 fixed by bumping transformers>=5.0.0)
```

New tests added:
- `tests/test_generator.py` — 6 unit/integration tests: context formatting, detect_product_interest phrase matching, streaming mock
- `tests/test_api.py` — 6 tests: SSE streaming, PersonaSnapshot contract, health 200/503, default persona for unknown user
- `tests/test_cli.py` — 9 unit tests for SSE parsing edge cases + 3 e2e smoke tests (auto-skip when server not running)

## Design Decisions & Edge Cases

### Generator
- `detect_product_interest` uses keyword matching (no LLM call) to keep latency low. Matches interest phrases first, then product names longest-first to avoid partial matches (e.g., "Shirt" matching before "Linen Shirt").
- System prompt explicitly prohibits asking the user about preferences — inference only.
- Provider-agnostic: `AsyncOpenAI(base_url=chat_llm.base_url, api_key=chat_llm.api_key)` — swap Groq→OpenAI via `CHAT_BASE_URL` env var.

### FastAPI / SSE
- Persona update runs as a fire-and-forget coroutine (`asyncio.ensure_future`) after the streaming generator starts — the response is never blocked on persona writes.
- Outfit building is conditional on `detect_product_interest` returning a product_id. If the user isn't showing interest in a specific item, no outfit query is issued.
- `/health` returns 503 (not 200) when Neo4j is down so load balancers can pull the instance automatically.

### Rich CLI
- Uses `httpx` (not `requests`) for SSE streaming since it supports streaming context managers with `client.stream()`.
- Structured payloads (product citations, outfit tables) are sent inline as `__JSON__` prefixed SSE chunks so the CLI can render them with Rich while the text continues streaming.
- `daemon=True` on the uvicorn thread means the server shuts down automatically when the main thread exits — no explicit teardown needed.

### CVE Fix
- `transformers 4.57.6` (pulled in transitively by `sentence-transformers`) had CVE-2026-1839. Added `transformers>=5.0.0` as a direct dependency; resolved to 5.7.0 which is clean.

## Things to Consider for Wave 4
- Langfuse tracing hooks (issue #14) should wrap the generator's `stream_response` and the chat endpoint's full pipeline
- The test suite needs an integration fixture for the full FastAPI app with a live Neo4j (currently 5 integration tests are skipped)
- The `explain` flag is wired through all layers but the CLI `--explain` argument parsing could be made more prominent