### PR TITLE
feat: wave-7 spec compliance — top_occasions, materials, explain, citations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,4 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+.claude/worktrees/

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
-.PHONY: qgate lint format type-check test audit chat seed
+.PHONY: qgate lint format type-check test test-unit test-integration test-e2e \
+       audit chat seed embed seed-and-embed setup dev health \
+       db-up db-down up down clean pre-commit-install
 
-qgate:
+# ── Quality Gate ────────────────────────────────────────────────────────────────
+
+qgate: lint-check format-check type-check audit
+
+lint-check:
 	uv run ruff check src/ tests/ scripts/
-	uv run ruff format --check src/ tests/ scripts/
-	uv run pyright
-	uv run pip-audit
 
 lint:
 	uv run ruff check --fix src/ tests/ scripts/
+
+format-check:
+	uv run ruff format --check src/ tests/ scripts/
 
 format:
 	uv run ruff format src/ tests/ scripts/
@@ -15,17 +21,83 @@ format:
 type-check:
 	uv run pyright
 
-test:
-	uv run pytest -v
-
 audit:
 	uv run pip-audit
 
-chat:
-	uv run python -m stylemind
+# ── Tests ───────────────────────────────────────────────────────────────────────
+
+test:
+	uv run pytest -v
+
+test-unit:
+	uv run pytest -m unit -v
+
+test-integration:
+	uv run pytest -m integration -v
+
+test-e2e:
+	uv run pytest -m e2e -v
+
+test-perf:
+	uv run pytest -m performance -v
+
+# ── Data Pipeline ───────────────────────────────────────────────────────────────
 
 seed:
 	uv run python scripts/seed.py
 
 embed:
 	uv run python scripts/embed.py
+
+seed-and-embed: seed embed
+
+# ── Run ─────────────────────────────────────────────────────────────────────────
+
+chat:
+	uv run python -m stylemind
+
+dev:
+	uv run uvicorn stylemind.main:app --reload --host 127.0.0.1 --port 8000
+
+health:
+	@curl -sf http://localhost:8000/health && echo " OK" || echo " FAIL (is the server running?)"
+
+# ── Docker ──────────────────────────────────────────────────────────────────────
+
+db-up:
+	docker compose up -d neo4j
+	@echo "Waiting for Neo4j healthcheck..."
+	@until docker compose exec neo4j cypher-shell -u neo4j -p "$${NEO4J_PASSWORD:-stylemind_secret}" "RETURN 1" > /dev/null 2>&1; do sleep 2; done
+	@echo "Neo4j ready at bolt://localhost:7687 — browser at http://localhost:7474"
+
+db-down:
+	docker compose down neo4j
+
+up:
+	docker compose up --build -d
+	@echo "App: http://localhost:8000  Neo4j: http://localhost:7474  Langfuse: http://localhost:3000"
+
+down:
+	docker compose down
+
+# ── Setup ───────────────────────────────────────────────────────────────────────
+
+setup: pre-commit-install
+	@test -f .env || (cp .env.example .env && echo "Created .env from .env.example — edit API keys before running")
+	uv sync
+	@echo ""
+	@echo "Setup complete. Next steps:"
+	@echo "  1. Edit .env with your API keys (CHAT_API_KEY, EXTRACTION_API_KEY)"
+	@echo "  2. make db-up              # start Neo4j"
+	@echo "  3. make seed-and-embed     # load data + embeddings"
+	@echo "  4. make chat               # start chatting"
+
+pre-commit-install:
+	uv run pre-commit install
+
+clean:
+	docker compose down -v
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .ruff_cache -exec rm -rf {} + 2>/dev/null || true
+	@echo "Cleaned caches and Docker volumes"

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -115,6 +115,22 @@ def seed(driver) -> None:  # type: ignore[type-arg]
     )
 
     with driver.session() as session:
+        constraints = [
+            "CREATE CONSTRAINT product_id_unique IF NOT EXISTS FOR (p:Product) REQUIRE p.product_id IS UNIQUE",
+            "CREATE CONSTRAINT brand_name_unique IF NOT EXISTS FOR (b:Brand) REQUIRE b.name IS UNIQUE",
+            "CREATE CONSTRAINT aesthetic_name_unique IF NOT EXISTS FOR (a:Aesthetic) REQUIRE a.name IS UNIQUE",
+            "CREATE CONSTRAINT occasion_name_unique IF NOT EXISTS FOR (o:Occasion) REQUIRE o.name IS UNIQUE",
+            "CREATE CONSTRAINT body_type_name_unique IF NOT EXISTS FOR (bt:BodyType) REQUIRE bt.name IS UNIQUE",
+            "CREATE CONSTRAINT color_name_unique IF NOT EXISTS FOR (cp:ColorPalette) REQUIRE cp.name IS UNIQUE",
+            "CREATE CONSTRAINT material_name_unique IF NOT EXISTS FOR (m:Material) REQUIRE m.name IS UNIQUE",
+            "CREATE CONSTRAINT season_name_unique IF NOT EXISTS FOR (s:Season) REQUIRE s.name IS UNIQUE",
+            "CREATE CONSTRAINT budget_label_unique IF NOT EXISTS FOR (bt:BudgetTier) REQUIRE bt.label IS UNIQUE",
+            "CREATE CONSTRAINT persona_uid_unique IF NOT EXISTS FOR (sp:StylePersona) REQUIRE sp.user_id IS UNIQUE",
+        ]
+        for constraint in constraints:
+            session.run(constraint)
+        logger.info("Created uniqueness constraints count=%d", len(constraints))
+
         # ------------------------------------------------------------------
         # 1. Nodes
         # ------------------------------------------------------------------
@@ -229,10 +245,11 @@ def seed(driver) -> None:  # type: ignore[type-arg]
                 if season:
                     session.run(Q.REL_PRODUCT_BEST_IN_SEASON, {"product_id": pid, "season_name": season})
 
-            # IN_COLOR ColorPalette (take first palette if pipe-separated)
-            cp = p["color_palette"].split("|")[0].strip()
-            if cp:
-                session.run(Q.REL_PRODUCT_IN_COLOR, {"product_id": pid, "palette_name": cp})
+            # IN_COLOR ColorPalette — pipe-separated (create IN_COLOR for each palette)
+            for palette in p["color_palette"].split("|"):
+                palette = palette.strip()
+                if palette and palette in COLOR_PALETTE_METADATA:
+                    session.run(Q.REL_PRODUCT_IN_COLOR, {"product_id": pid, "palette_name": palette})
 
             # AT_TIER BudgetTier
             tier = p["budget_tier"].strip()

--- a/src/stylemind/api/chat.py
+++ b/src/stylemind/api/chat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import logging
 from collections.abc import AsyncGenerator
 
@@ -53,6 +54,7 @@ async def _sse_stream(
 
     # 3. Rerank with persona signals
     reranked_products = retrieved_products
+    rerank_results: list = []
     if reranker is not None and retrieved_products:
         try:
             rerank_results = reranker.rerank(retrieved_products, persona, explain=chat_request.explain)
@@ -93,6 +95,27 @@ async def _sse_stream(
             yield "data: Sorry, an error occurred while generating the response.\n\n"
     else:
         yield "data: StyleMind generator not available.\n\n"
+
+    # 6. Emit structured JSON events (before [DONE])
+    if reranked_products:
+        sources_payload = [
+            {
+                "product_id": p.product_id,
+                "name": p.name,
+                "brand": p.brand,
+                "price_inr": p.price,
+                "score": p.similarity_score,
+            }
+            for p in reranked_products
+        ]
+        yield f"data: __JSON__{json.dumps({'sources': sources_payload})}\n\n"
+
+    if chat_request.explain and rerank_results:
+        explain_payload = [
+            r.breakdown.to_dict() for r in rerank_results if r.breakdown is not None
+        ]
+        if explain_payload:
+            yield f"data: __JSON__{json.dumps({'explain': explain_payload})}\n\n"
 
     yield "data: [DONE]\n\n"
 

--- a/src/stylemind/api/chat.py
+++ b/src/stylemind/api/chat.py
@@ -111,9 +111,7 @@ async def _sse_stream(
         yield f"data: __JSON__{json.dumps({'sources': sources_payload})}\n\n"
 
     if chat_request.explain and rerank_results:
-        explain_payload = [
-            r.breakdown.to_dict() for r in rerank_results if r.breakdown is not None
-        ]
+        explain_payload = [r.breakdown.to_dict() for r in rerank_results if r.breakdown is not None]
         if explain_payload:
             yield f"data: __JSON__{json.dumps({'explain': explain_payload})}\n\n"
 

--- a/src/stylemind/cli/chat.py
+++ b/src/stylemind/cli/chat.py
@@ -118,7 +118,7 @@ class ChatCLI:
     # ------------------------------------------------------------------
 
     def _handle_structured(self, json_str: str) -> None:
-        """Render product citations and outfit suggestions if present."""
+        """Render product citations, explain breakdowns, and outfit suggestions if present."""
         try:
             payload = json.loads(json_str)
         except json.JSONDecodeError:
@@ -126,13 +126,37 @@ class ChatCLI:
             return
 
         sources: list[dict[str, Any]] = payload.get("sources", [])
+        explain: list[dict[str, Any]] = payload.get("explain", [])
         outfit: dict[str, Any] | None = payload.get("outfit")
 
         if sources:
             self._render_sources(sources)
 
+        if explain:
+            self._render_explain(explain)
+
         if outfit:
             self._render_outfit(outfit)
+
+    def _render_explain(self, explain: list[dict[str, Any]]) -> None:
+        content_lines = []
+        for e in explain:
+            pid = e.get("product_id", "?")
+            base = e.get("base_score", 0.0)
+            boost = e.get("persona_boost", 0.0)
+            penalty = e.get("penalty", 0.0)
+            budget = e.get("budget_boost", 0.0)
+            final = e.get("final_score", 0.0)
+            content_lines.append(
+                f"• [bold]{pid}[/bold]  base={base:.3f}  boost={boost:+.3f}  penalty={penalty:+.3f}  budget={budget:+.3f}  →  [cyan]{final:.3f}[/cyan]"
+            )
+
+        panel = Panel(
+            "\n".join(content_lines),
+            title="[bold yellow]Score Breakdown[/bold yellow]",
+            expand=False,
+        )
+        self.console.print(panel)
 
     def _render_sources(self, sources: list[dict[str, Any]]) -> None:
         content_lines = []

--- a/src/stylemind/graph/queries.py
+++ b/src/stylemind/graph/queries.py
@@ -202,12 +202,14 @@ OPTIONAL MATCH (p)-[:FITS_OCCASION]->(o:Occasion)
 OPTIONAL MATCH (p)-[:IN_COLOR]->(cp:ColorPalette)
 OPTIONAL MATCH (p)-[:BEST_IN_SEASON]->(s:Season)
 OPTIONAL MATCH (p)-[:AT_TIER]->(bt:BudgetTier)
+OPTIONAL MATCH (p)-[:MADE_FROM]->(m:Material)
 OPTIONAL MATCH (p)-[:PAIRS_WITH]-(partner:Product)
 WITH p, b, bt, score,
      collect(DISTINCT a.name) AS aesthetics,
      collect(DISTINCT o.name) AS occasions,
      collect(DISTINCT cp.name) AS colors,
      collect(DISTINCT s.name) AS seasons,
+     collect(DISTINCT m.name) AS materials,
      collect(DISTINCT partner.product_id) AS pairs_with
 RETURN p.product_id AS product_id,
        p.name AS name,
@@ -216,6 +218,6 @@ RETURN p.product_id AS product_id,
        p.category AS category,
        b.name AS brand,
        coalesce(bt.label, p.budget_tier) AS budget_tier,
-       aesthetics, occasions, colors, seasons, pairs_with, score
+       aesthetics, occasions, colors, seasons, materials, pairs_with, score
 ORDER BY score DESC
 """

--- a/src/stylemind/models/domain.py
+++ b/src/stylemind/models/domain.py
@@ -48,6 +48,7 @@ class RetrievedProduct:
     occasions: list[str] = field(default_factory=list)
     colors: list[str] = field(default_factory=list)
     seasons: list[str] = field(default_factory=list)
+    materials: list[str] = field(default_factory=list)
     pairs_with: list[str] = field(default_factory=list)
     similarity_score: float = 0.0
 

--- a/src/stylemind/models/schemas.py
+++ b/src/stylemind/models/schemas.py
@@ -49,6 +49,7 @@ class PersonaSnapshot(BaseModel):
 
     preferred_aesthetics: list[str] = Field(default_factory=list)
     disliked_materials: list[str] = Field(default_factory=list)
+    disliked_products: list[str] = Field(default_factory=list)
     budget_tier: str | None = None
     top_occasions: list[str] = Field(default_factory=list)
     disliked_products: list[str] = Field(default_factory=list)

--- a/src/stylemind/models/schemas.py
+++ b/src/stylemind/models/schemas.py
@@ -49,6 +49,7 @@ class PersonaSnapshot(BaseModel):
 
     preferred_aesthetics: list[str] = Field(default_factory=list)
     disliked_materials: list[str] = Field(default_factory=list)
+    disliked_products: list[str] = Field(default_factory=list)
     budget_tier: str | None = None
     top_occasions: list[str] = Field(default_factory=list)
     confidence_score: float = 0.0

--- a/src/stylemind/models/schemas.py
+++ b/src/stylemind/models/schemas.py
@@ -51,6 +51,7 @@ class PersonaSnapshot(BaseModel):
     disliked_materials: list[str] = Field(default_factory=list)
     budget_tier: str | None = None
     top_occasions: list[str] = Field(default_factory=list)
+    disliked_products: list[str] = Field(default_factory=list)
     confidence_score: float = 0.0
 
 

--- a/src/stylemind/persona/inference.py
+++ b/src/stylemind/persona/inference.py
@@ -61,6 +61,7 @@ _PERSONA_JSON_SCHEMA = {
     "additionalProperties": False,
 }
 
+
 class PersonaInferenceEngine:
     def __init__(self, config: ExtractionLLMConfig) -> None:
         self._client = OpenAI(base_url=config.base_url, api_key=config.api_key)

--- a/src/stylemind/persona/inference.py
+++ b/src/stylemind/persona/inference.py
@@ -36,6 +36,31 @@ User: "I'm on a tight budget"
 """
 
 
+_PERSONA_JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "liked_aesthetics": {"type": "array", "items": {"type": "string"}},
+        "disliked_materials": {"type": "array", "items": {"type": "string"}},
+        "mentioned_occasions": {"type": "array", "items": {"type": "string"}},
+        "budget_signal": {"type": ["string", "null"]},
+        "color_preferences": {"type": "array", "items": {"type": "string"}},
+        "brand_mentions": {"type": "array", "items": {"type": "string"}},
+        "sentiment_on_shown": {"type": "object", "additionalProperties": {"type": "string"}},
+        "signal_strength": {"type": "number"},
+    },
+    "required": [
+        "liked_aesthetics",
+        "disliked_materials",
+        "mentioned_occasions",
+        "budget_signal",
+        "color_preferences",
+        "brand_mentions",
+        "sentiment_on_shown",
+        "signal_strength",
+    ],
+    "additionalProperties": False,
+}
+
 class PersonaInferenceEngine:
     def __init__(self, config: ExtractionLLMConfig) -> None:
         self._client = OpenAI(base_url=config.base_url, api_key=config.api_key)
@@ -59,7 +84,7 @@ class PersonaInferenceEngine:
             PersonaSignals with extracted signals, or empty PersonaSignals on any failure.
         """
         try:
-            recent_history = history[-6:]  # last 3 turns = 6 messages (user + assistant pairs)
+            recent_history = history[-6:]
 
             context_parts: list[str] = []
             if recent_history:
@@ -78,29 +103,38 @@ class PersonaInferenceEngine:
             else:
                 user_content = message
 
-            response = self._client.chat.completions.create(
-                model=self._model,
-                messages=[
-                    {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
-                    {"role": "user", "content": user_content},
-                ],
-                response_format={"type": "json_object"},
-                temperature=0,
-            )
+            try:
+                response = self._client.chat.completions.create(
+                    model=self._model,
+                    messages=[
+                        {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
+                        {"role": "user", "content": user_content},
+                    ],
+                    response_format={
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": "PersonaSignals",
+                            "schema": _PERSONA_JSON_SCHEMA,
+                            "strict": True,
+                        },
+                    },
+                    temperature=0,
+                )
+            except Exception:
+                response = self._client.chat.completions.create(
+                    model=self._model,
+                    messages=[
+                        {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
+                        {"role": "user", "content": user_content},
+                    ],
+                    response_format={"type": "json_object"},
+                    temperature=0,
+                )
 
             raw_content = response.choices[0].message.content or "{}"
             data = json.loads(raw_content)
+            signals = PersonaSignals.model_validate(data)
 
-            signals = PersonaSignals(
-                liked_aesthetics=data.get("liked_aesthetics", []),
-                disliked_materials=data.get("disliked_materials", []),
-                mentioned_occasions=data.get("mentioned_occasions", []),
-                budget_signal=data.get("budget_signal"),
-                color_preferences=data.get("color_preferences", []),
-                brand_mentions=data.get("brand_mentions", []),
-                sentiment_on_shown=data.get("sentiment_on_shown", {}),
-                signal_strength=float(data.get("signal_strength", 0.5)),
-            )
             logger.info(
                 "persona signals extracted signal_strength=%.2f liked_aesthetics=%s",
                 signals.signal_strength,

--- a/src/stylemind/persona/manager.py
+++ b/src/stylemind/persona/manager.py
@@ -86,6 +86,12 @@ ON CREATE SET r.weight = 0, r.last_seen_turn = $turn
 SET r.weight = r.weight + $weight, r.last_seen_turn = $turn
 """
 
+GET_DISLIKED_PRODUCTS = """
+MATCH (sp:StylePersona {user_id: $user_id})
+OPTIONAL MATCH (sp)-[rd:DISLIKES]->(p:Product)
+RETURN collect(DISTINCT p.product_id) AS disliked_product_ids
+"""
+
 
 class PersonaManager:
     def __init__(self, driver: Driver, decay_rate: float = 0.15, expected_signals_per_turn: float = 3.0) -> None:
@@ -140,6 +146,45 @@ class PersonaManager:
             if name:
                 disliked_materials.append(name)
 
+        # Fetch occasions with temporal decay (top 3 by decayed weight)
+        top_occasions: list[str] = []
+        try:
+            occ_result = self._driver.execute_query(
+                GET_OCCASIONS_DATA,
+                {"user_id": user_id},
+                database_="neo4j",
+            )
+            occ_records = [record.data() for record in occ_result.records]
+            if occ_records:
+                occasions_raw: list[dict[str, Any]] = occ_records[0].get("occasions") or []
+                decayed_occasions: list[tuple[str, float]] = []
+                for occ in occasions_raw:
+                    occ_name = occ.get("occasion")
+                    occ_weight = occ.get("weight")
+                    occ_last_seen = occ.get("last_seen")
+                    if occ_name is None or occ_weight is None or occ_last_seen is None:
+                        continue
+                    effective = self._apply_decay(float(occ_weight), int(occ_last_seen), turn_count)
+                    decayed_occasions.append((occ_name, effective))
+                decayed_occasions.sort(key=lambda x: x[1], reverse=True)
+                top_occasions = [name for name, _ in decayed_occasions[:3]]
+        except Exception as exc:
+            logger.warning("persona get_occasions query failed user_id=%s error=%s", user_id, exc)
+
+        # Fetch disliked products (no decay — dislikes are persistent)
+        disliked_products: list[str] = []
+        try:
+            dp_result = self._driver.execute_query(
+                GET_DISLIKED_PRODUCTS,
+                {"user_id": user_id},
+                database_="neo4j",
+            )
+            dp_records = [record.data() for record in dp_result.records]
+            if dp_records:
+                disliked_products = dp_records[0].get("disliked_product_ids") or []
+        except Exception as exc:
+            logger.warning("persona get_disliked_products query failed user_id=%s error=%s", user_id, exc)
+
         # Budget tier: weighted mode (most frequent budget signal)
         budget_tier: str | None = None
         if budget_signals:
@@ -159,7 +204,8 @@ class PersonaManager:
             preferred_aesthetics=preferred_aesthetics,
             disliked_materials=disliked_materials,
             budget_tier=budget_tier,
-            top_occasions=[],
+            top_occasions=top_occasions,
+            disliked_products=disliked_products,
             confidence_score=confidence,
         )
 

--- a/src/stylemind/persona/manager.py
+++ b/src/stylemind/persona/manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import math
-from collections import Counter
 from typing import Any
 
 from neo4j import Driver
@@ -57,8 +56,8 @@ SET r.weight = r.weight + $weight, r.last_seen_turn = $turn
 SET_BUDGET_SIGNAL = """
 MATCH (sp:StylePersona {user_id: $user_id})
 SET sp.budget_signals = CASE
-    WHEN sp.budget_signals IS NULL THEN [$budget_signal]
-    ELSE sp.budget_signals + [$budget_signal]
+    WHEN sp.budget_signals IS NULL THEN [$budget_entry]
+    ELSE sp.budget_signals + [$budget_entry]
 END
 """
 
@@ -140,11 +139,16 @@ class PersonaManager:
             if name:
                 disliked_materials.append(name)
 
-        # Budget tier: weighted mode (most frequent budget signal)
-        budget_tier: str | None = None
-        if budget_signals:
-            counter = Counter(budget_signals)
-            budget_tier = counter.most_common(1)[0][0]
+        budget_weights: dict[str, float] = {}
+        for entry in budget_signals:
+            if isinstance(entry, dict):
+                sig = entry.get("signal", "")
+                w = float(entry.get("weight", 1.0))
+            else:
+                sig = str(entry)
+                w = 1.0
+            budget_weights[sig] = budget_weights.get(sig, 0.0) + w
+        budget_tier: str | None = max(budget_weights, key=lambda k: budget_weights[k]) if budget_weights else None
 
         confidence = self._confidence_score(decayed_weights, turn_count)
 
@@ -238,7 +242,7 @@ class PersonaManager:
                 try:
                     self._driver.execute_query(
                         SET_BUDGET_SIGNAL,
-                        {"user_id": user_id, "budget_signal": signals.budget_signal},
+                        {"user_id": user_id, "budget_entry": {"signal": signals.budget_signal, "weight": signals.signal_strength}},
                         database_="neo4j",
                     )
                 except Exception as exc:

--- a/src/stylemind/persona/manager.py
+++ b/src/stylemind/persona/manager.py
@@ -289,7 +289,10 @@ class PersonaManager:
                 try:
                     self._driver.execute_query(
                         SET_BUDGET_SIGNAL,
-                        {"user_id": user_id, "budget_entry": {"signal": signals.budget_signal, "weight": signals.signal_strength}},
+                        {
+                            "user_id": user_id,
+                            "budget_entry": {"signal": signals.budget_signal, "weight": signals.signal_strength},
+                        },
                         database_="neo4j",
                     )
                 except Exception as exc:

--- a/src/stylemind/persona/manager.py
+++ b/src/stylemind/persona/manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import math
-from collections import Counter
 from typing import Any
 
 from neo4j import Driver
@@ -57,8 +56,8 @@ SET r.weight = r.weight + $weight, r.last_seen_turn = $turn
 SET_BUDGET_SIGNAL = """
 MATCH (sp:StylePersona {user_id: $user_id})
 SET sp.budget_signals = CASE
-    WHEN sp.budget_signals IS NULL THEN [$budget_signal]
-    ELSE sp.budget_signals + [$budget_signal]
+    WHEN sp.budget_signals IS NULL THEN [$budget_entry]
+    ELSE sp.budget_signals + [$budget_entry]
 END
 """
 
@@ -185,11 +184,17 @@ class PersonaManager:
         except Exception as exc:
             logger.warning("persona get_disliked_products query failed user_id=%s error=%s", user_id, exc)
 
-        # Budget tier: weighted mode (most frequent budget signal)
-        budget_tier: str | None = None
-        if budget_signals:
-            counter = Counter(budget_signals)
-            budget_tier = counter.most_common(1)[0][0]
+        # Budget tier: weighted accumulation
+        budget_weights: dict[str, float] = {}
+        for entry in budget_signals:
+            if isinstance(entry, dict):
+                sig = entry.get("signal", "")
+                w = float(entry.get("weight", 1.0))
+            else:
+                sig = str(entry)
+                w = 1.0
+            budget_weights[sig] = budget_weights.get(sig, 0.0) + w
+        budget_tier: str | None = max(budget_weights, key=lambda k: budget_weights[k]) if budget_weights else None
 
         confidence = self._confidence_score(decayed_weights, turn_count)
 
@@ -284,7 +289,7 @@ class PersonaManager:
                 try:
                     self._driver.execute_query(
                         SET_BUDGET_SIGNAL,
-                        {"user_id": user_id, "budget_signal": signals.budget_signal},
+                        {"user_id": user_id, "budget_entry": {"signal": signals.budget_signal, "weight": signals.signal_strength}},
                         database_="neo4j",
                     )
                 except Exception as exc:

--- a/src/stylemind/rag/reranker.py
+++ b/src/stylemind/rag/reranker.py
@@ -24,6 +24,16 @@ class ScoreBreakdown:
     budget_boost: float
     final_score: float
 
+    def to_dict(self) -> dict[str, float | str]:
+        return {
+            "product_id": self.product_id,
+            "base_score": self.base_score,
+            "persona_boost": self.persona_boost,
+            "penalty": self.persona_penalty,
+            "budget_boost": self.budget_boost,
+            "final_score": self.final_score,
+        }
+
 
 @dataclass(frozen=True)
 class RerankResult:

--- a/src/stylemind/rag/reranker.py
+++ b/src/stylemind/rag/reranker.py
@@ -77,15 +77,13 @@ class ProductReranker:
 
             # --- persona penalty ---
             persona_penalty = 0.0
-            if confidence > 0.0 and persona.disliked_materials:
-                # Penalise if any candidate aesthetic or category signals a disliked material context.
-                # We compare lowercased tokens broadly so "Cotton" matches "cotton blend" etc.
+            if confidence > 0.0:
                 disliked_lower = {m.lower() for m in persona.disliked_materials}
-                candidate_tokens = {candidate.category.lower(), candidate.brand.lower()}
-                for aesthetic in candidate.aesthetics:
-                    candidate_tokens.add(aesthetic.lower())
-                if candidate_tokens & disliked_lower:
-                    persona_penalty = _PERSONA_PENALTY * confidence
+                candidate_materials_lower = {m.lower() for m in candidate.materials}
+                if candidate_materials_lower & disliked_lower:
+                    persona_penalty += _PERSONA_PENALTY * confidence
+                if persona.disliked_products and candidate.product_id in persona.disliked_products:
+                    persona_penalty += _PERSONA_PENALTY * confidence
 
             # --- budget boost ---
             budget_boost = 0.0

--- a/src/stylemind/rag/retriever.py
+++ b/src/stylemind/rag/retriever.py
@@ -26,6 +26,7 @@ def _row_to_retrieved_product(row: dict[str, Any]) -> RetrievedProduct:
         occasions=row["occasions"] or [],
         colors=row["colors"] or [],
         seasons=row["seasons"] or [],
+        materials=row.get("materials") or [],
         pairs_with=row["pairs_with"] or [],
         similarity_score=row["score"],
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,9 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from stylemind.models.domain import RetrievedProduct
 from stylemind.models.schemas import PersonaSnapshot
+from stylemind.rag.reranker import RerankResult, ScoreBreakdown
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
@@ -215,3 +217,168 @@ def test_persona_endpoint_returns_default_when_no_data():
     assert data["preferred_aesthetics"] == []
     assert data["confidence_score"] == 0.0
     assert data["budget_tier"] is None
+
+
+# ---------------------------------------------------------------------------
+# SSE __JSON__ events
+# ---------------------------------------------------------------------------
+
+
+def _make_products():
+    return [
+        RetrievedProduct(
+            product_id="P001",
+            name="Linen Trouser",
+            description="test",
+            price=4200,
+            category="Bottoms",
+            brand="COS",
+            budget_tier="Mid",
+            aesthetics=["Quiet Luxury"],
+            occasions=["Office"],
+            colors=["Neutrals"],
+            seasons=["SS"],
+            pairs_with=[],
+            similarity_score=0.85,
+        ),
+        RetrievedProduct(
+            product_id="P005",
+            name="Ribbed Polo",
+            description="test",
+            price=1800,
+            category="Tops",
+            brand="Uniqlo",
+            budget_tier="Budget",
+            aesthetics=["Streetwear"],
+            occasions=["Casual"],
+            colors=["Neutrals"],
+            seasons=["Year-round"],
+            pairs_with=[],
+            similarity_score=0.78,
+        ),
+    ]
+
+
+def _make_rerank_results(products, explain=False):
+    results = []
+    for p in products:
+        breakdown = None
+        if explain:
+            breakdown = ScoreBreakdown(
+                product_id=p.product_id,
+                base_score=p.similarity_score,
+                persona_boost=0.04,
+                persona_penalty=0.0,
+                budget_boost=0.0,
+                final_score=p.similarity_score + 0.04,
+            )
+        results.append(RerankResult(product=p, final_score=p.similarity_score + (0.04 if explain else 0.0), breakdown=breakdown))
+    return results
+
+
+def _parse_sse_data(response):
+    payloads = []
+    for line in response.text.splitlines():
+        if line.startswith("data: "):
+            payloads.append(line[6:])
+    return payloads
+
+
+@pytest.mark.integration
+def test_chat_emits_sources_json_event():
+    products = _make_products()
+    rerank_results = _make_rerank_results(products, explain=False)
+
+    app = _make_app_with_mocks(stream_chunks=["Hello"])
+
+    mock_retriever = app.state.retriever
+    mock_retriever.retrieve = MagicMock(return_value=products)
+
+    mock_reranker = app.state.reranker
+    mock_reranker.rerank = MagicMock(return_value=rerank_results)
+
+    client = TestClient(app, raise_server_exceptions=True)
+    response = client.post("/chat", json={"user_id": "u1", "message": "test"})
+
+    assert response.status_code == 200
+    payloads = _parse_sse_data(response)
+
+    sources_events = [p for p in payloads if p.startswith("__JSON__") and '"sources"' in p]
+    assert len(sources_events) == 1
+
+    import json
+
+    data = json.loads(sources_events[0][8:])
+    assert len(data["sources"]) == 2
+    assert data["sources"][0]["product_id"] == "P001"
+    assert data["sources"][0]["name"] == "Linen Trouser"
+    assert data["sources"][0]["brand"] == "COS"
+    assert data["sources"][0]["price_inr"] == 4200
+
+
+@pytest.mark.integration
+def test_chat_emits_explain_json_event_when_explain_true():
+    products = _make_products()
+    rerank_results = _make_rerank_results(products, explain=True)
+
+    app = _make_app_with_mocks(stream_chunks=["Hello"])
+
+    mock_retriever = app.state.retriever
+    mock_retriever.retrieve = MagicMock(return_value=products)
+
+    mock_reranker = app.state.reranker
+    mock_reranker.rerank = MagicMock(return_value=rerank_results)
+
+    client = TestClient(app, raise_server_exceptions=True)
+    response = client.post("/chat", json={"user_id": "u1", "message": "test", "explain": True})
+
+    assert response.status_code == 200
+    payloads = _parse_sse_data(response)
+
+    import json
+
+    explain_events = [p for p in payloads if p.startswith("__JSON__") and '"explain"' in p]
+    assert len(explain_events) == 1
+
+    data = json.loads(explain_events[0][8:])
+    assert len(data["explain"]) == 2
+    assert data["explain"][0]["product_id"] == "P001"
+    assert data["explain"][0]["base_score"] == pytest.approx(0.85)
+    assert data["explain"][0]["persona_boost"] == pytest.approx(0.04)
+    assert data["explain"][0]["penalty"] == pytest.approx(0.0)
+    assert data["explain"][0]["final_score"] == pytest.approx(0.89)
+
+
+@pytest.mark.integration
+def test_chat_no_explain_event_when_explain_false():
+    products = _make_products()
+    rerank_results = _make_rerank_results(products, explain=False)
+
+    app = _make_app_with_mocks(stream_chunks=["Hello"])
+
+    mock_retriever = app.state.retriever
+    mock_retriever.retrieve = MagicMock(return_value=products)
+
+    mock_reranker = app.state.reranker
+    mock_reranker.rerank = MagicMock(return_value=rerank_results)
+
+    client = TestClient(app, raise_server_exceptions=True)
+    response = client.post("/chat", json={"user_id": "u1", "message": "test", "explain": False})
+
+    assert response.status_code == 200
+    payloads = _parse_sse_data(response)
+
+    explain_events = [p for p in payloads if p.startswith("__JSON__") and '"explain"' in p]
+    assert len(explain_events) == 0
+
+
+@pytest.mark.unit
+def test_score_breakdown_to_dict():
+    sb = ScoreBreakdown(product_id="P001", base_score=0.85, persona_boost=0.04, persona_penalty=0.0, budget_boost=0.02, final_score=0.91)
+    d = sb.to_dict()
+    assert d["product_id"] == "P001"
+    assert d["base_score"] == pytest.approx(0.85)
+    assert d["persona_boost"] == pytest.approx(0.04)
+    assert d["penalty"] == pytest.approx(0.0)
+    assert d["budget_boost"] == pytest.approx(0.02)
+    assert d["final_score"] == pytest.approx(0.91)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -272,7 +272,9 @@ def _make_rerank_results(products, explain=False):
                 budget_boost=0.0,
                 final_score=p.similarity_score + 0.04,
             )
-        results.append(RerankResult(product=p, final_score=p.similarity_score + (0.04 if explain else 0.0), breakdown=breakdown))
+        results.append(
+            RerankResult(product=p, final_score=p.similarity_score + (0.04 if explain else 0.0), breakdown=breakdown)
+        )
     return results
 
 
@@ -374,7 +376,9 @@ def test_chat_no_explain_event_when_explain_false():
 
 @pytest.mark.unit
 def test_score_breakdown_to_dict():
-    sb = ScoreBreakdown(product_id="P001", base_score=0.85, persona_boost=0.04, persona_penalty=0.0, budget_boost=0.02, final_score=0.91)
+    sb = ScoreBreakdown(
+        product_id="P001", base_score=0.85, persona_boost=0.04, persona_penalty=0.0, budget_boost=0.02, final_score=0.91
+    )
     d = sb.to_dict()
     assert d["product_id"] == "P001"
     assert d["base_score"] == pytest.approx(0.85)

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -301,7 +301,7 @@ def test_persona_5_turn_evolution():
     # Track what would be stored in a simple in-memory structure
     stored_turn = 0
     stored_aesthetics: dict[str, dict] = {}  # name -> {weight, last_seen}
-    stored_budget_signals: list[str] = []
+    stored_budget_signals: list[dict[str, Any]] = []
 
     def execute_query_side_effect(query: str, params: dict, database_: str = "neo4j") -> MagicMock:
         nonlocal stored_turn
@@ -325,8 +325,8 @@ def test_persona_5_turn_evolution():
                 stored_aesthetics[name] = {"weight": w, "last_seen": t}
             result.records = []
 
-        elif "budget_signals" in query and "budget_signal" in params:
-            stored_budget_signals.append(params["budget_signal"])
+        elif "budget_signals" in query and "budget_entry" in params:
+            stored_budget_signals.append(params["budget_entry"])
             result.records = []
 
         elif "MATCH (sp:StylePersona" in query and "PREFERS" in query:

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -261,3 +261,175 @@ def test_first_write_weight_not_doubled() -> None:
     assert "ON CREATE SET r.weight = 0" in query, (
         "MERGE query should initialize weight to 0 on CREATE to prevent doubling"
     )
+
+
+@pytest.mark.unit
+def test_top_occasions_populated_with_decay() -> None:
+    """After turns with occasion signals, top_occasions is populated with decayed weights, top 3."""
+    driver = MagicMock()
+
+    persona_result = MagicMock()
+    persona_rec = MagicMock()
+    persona_rec.data.return_value = {
+        "turn_count": 3,
+        "budget_signals": None,
+        "preferences": [],
+        "dislikes": [],
+    }
+    persona_result.records = [persona_rec]
+
+    occasion_result = MagicMock()
+    occasion_rec = MagicMock()
+    occasion_rec.data.return_value = {
+        "occasions": [
+            {"occasion": "Date Night", "weight": 2.0, "last_seen": 3},
+            {"occasion": "Office", "weight": 1.5, "last_seen": 2},
+            {"occasion": "Casual", "weight": 0.5, "last_seen": 1},
+        ]
+    }
+    occasion_result.records = [occasion_rec]
+
+    disliked_result = MagicMock()
+    disliked_rec = MagicMock()
+    disliked_rec.data.return_value = {"disliked_product_ids": []}
+    disliked_result.records = [disliked_rec]
+
+    driver.execute_query.side_effect = [persona_result, occasion_result, disliked_result]
+
+    manager = _make_manager(driver)
+    snapshot = manager.get_persona("user_occasions")
+
+    assert len(snapshot.top_occasions) == 3
+    assert snapshot.top_occasions[0] == "Date Night"
+    assert snapshot.top_occasions[1] == "Office"
+    assert snapshot.top_occasions[2] == "Casual"
+
+
+@pytest.mark.unit
+def test_top_occasions_limited_to_three() -> None:
+    """top_occasions returns at most 3 entries even if more occasions exist."""
+    driver = MagicMock()
+
+    persona_result = MagicMock()
+    persona_rec = MagicMock()
+    persona_rec.data.return_value = {"turn_count": 5, "budget_signals": None, "preferences": [], "dislikes": []}
+    persona_result.records = [persona_rec]
+
+    occasion_result = MagicMock()
+    occasion_rec = MagicMock()
+    occasion_rec.data.return_value = {
+        "occasions": [
+            {"occasion": "Date Night", "weight": 4.0, "last_seen": 5},
+            {"occasion": "Office", "weight": 3.0, "last_seen": 5},
+            {"occasion": "Casual", "weight": 2.0, "last_seen": 5},
+            {"occasion": "Brunch", "weight": 1.0, "last_seen": 5},
+            {"occasion": "Wedding Guest", "weight": 0.5, "last_seen": 5},
+        ]
+    }
+    occasion_result.records = [occasion_rec]
+
+    disliked_result = MagicMock()
+    disliked_rec = MagicMock()
+    disliked_rec.data.return_value = {"disliked_product_ids": []}
+    disliked_result.records = [disliked_rec]
+
+    driver.execute_query.side_effect = [persona_result, occasion_result, disliked_result]
+
+    manager = _make_manager(driver)
+    snapshot = manager.get_persona("user_many_occasions")
+
+    assert len(snapshot.top_occasions) == 3
+    assert snapshot.top_occasions == ["Date Night", "Office", "Casual"]
+
+
+@pytest.mark.unit
+def test_disliked_products_populated() -> None:
+    """Negative sentiment on products populates disliked_products in snapshot."""
+    driver = MagicMock()
+
+    persona_result = MagicMock()
+    persona_rec = MagicMock()
+    persona_rec.data.return_value = {"turn_count": 2, "budget_signals": None, "preferences": [], "dislikes": []}
+    persona_result.records = [persona_rec]
+
+    occasion_result = MagicMock()
+    occasion_rec = MagicMock()
+    occasion_rec.data.return_value = {"occasions": []}
+    occasion_result.records = [occasion_rec]
+
+    disliked_result = MagicMock()
+    disliked_rec = MagicMock()
+    disliked_rec.data.return_value = {"disliked_product_ids": ["P012", "P045"]}
+    disliked_result.records = [disliked_rec]
+
+    driver.execute_query.side_effect = [persona_result, occasion_result, disliked_result]
+
+    manager = _make_manager(driver)
+    snapshot = manager.get_persona("user_dislike")
+
+    assert "P012" in snapshot.disliked_products
+    assert "P045" in snapshot.disliked_products
+
+
+@pytest.mark.unit
+def test_occasion_decay_ordering() -> None:
+    """Occasion with older last_seen decays below a newer but lighter occasion."""
+    driver = MagicMock()
+
+    persona_result = MagicMock()
+    persona_rec = MagicMock()
+    persona_rec.data.return_value = {"turn_count": 10, "budget_signals": None, "preferences": [], "dislikes": []}
+    persona_result.records = [persona_rec]
+
+    occasion_result = MagicMock()
+    occasion_rec = MagicMock()
+    occasion_rec.data.return_value = {
+        "occasions": [
+            {"occasion": "Office", "weight": 3.0, "last_seen": 1},
+            {"occasion": "Date Night", "weight": 1.0, "last_seen": 10},
+        ]
+    }
+    occasion_result.records = [occasion_rec]
+
+    disliked_result = MagicMock()
+    disliked_rec = MagicMock()
+    disliked_rec.data.return_value = {"disliked_product_ids": []}
+    disliked_result.records = [disliked_rec]
+
+    driver.execute_query.side_effect = [persona_result, occasion_result, disliked_result]
+
+    manager = _make_manager(driver)
+    snapshot = manager.get_persona("user_decay_order")
+
+    # Office: 3.0 * exp(-0.15 * 9) ≈ 3.0 * 0.2592 ≈ 0.778
+    # Date Night: 1.0 * exp(-0.15 * 0) = 1.0
+    # Date Night should rank higher despite lower raw weight
+    assert snapshot.top_occasions[0] == "Date Night"
+
+
+@pytest.mark.unit
+def test_disliked_products_empty_when_none() -> None:
+    """disliked_products defaults to empty list when query returns no data."""
+    driver = MagicMock()
+
+    persona_result = MagicMock()
+    persona_rec = MagicMock()
+    persona_rec.data.return_value = {"turn_count": 1, "budget_signals": None, "preferences": [], "dislikes": []}
+    persona_result.records = [persona_rec]
+
+    occasion_result = MagicMock()
+    occasion_rec = MagicMock()
+    occasion_rec.data.return_value = {"occasions": []}
+    occasion_result.records = [occasion_rec]
+
+    disliked_result = MagicMock()
+    disliked_rec = MagicMock()
+    disliked_rec.data.return_value = {"disliked_product_ids": None}
+    disliked_result.records = [disliked_rec]
+
+    driver.execute_query.side_effect = [persona_result, occasion_result, disliked_result]
+
+    manager = _make_manager(driver)
+    snapshot = manager.get_persona("user_no_dislikes")
+
+    assert snapshot.disliked_products == []

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -179,9 +179,7 @@ def test_weighted_budget_outranks_count() -> None:
 
     snapshot = manager.get_persona("user_weighted")
 
-    assert snapshot.budget_tier == "luxury", (
-        f"Expected 'luxury' (weighted 0.9 > 0.6), got {snapshot.budget_tier!r}"
-    )
+    assert snapshot.budget_tier == "luxury", f"Expected 'luxury' (weighted 0.9 > 0.6), got {snapshot.budget_tier!r}"
 
 
 @pytest.mark.unit

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -135,13 +135,17 @@ def test_confidence_grows_with_signals() -> None:
 
 @pytest.mark.unit
 def test_budget_accumulation() -> None:
-    """Multiple turns with same budget_signal → budget_tier set correctly via mode."""
-    # Simulate get_persona receiving a record with 3 'premium' and 1 'luxury' signals
+    """Multiple turns with same budget_signal -> budget_tier set correctly via weighted mode."""
     driver = _make_driver_with_records(
         [
             {
                 "turn_count": 4,
-                "budget_signals": ["premium", "premium", "luxury", "premium"],
+                "budget_signals": [
+                    {"signal": "premium", "weight": 0.8},
+                    {"signal": "premium", "weight": 0.6},
+                    {"signal": "luxury", "weight": 0.9},
+                    {"signal": "premium", "weight": 0.7},
+                ],
                 "preferences": [],
                 "dislikes": [],
             }
@@ -151,8 +155,33 @@ def test_budget_accumulation() -> None:
 
     snapshot = manager.get_persona("user_budget")
 
-    # Most common = "premium" (3 out of 4)
     assert snapshot.budget_tier == "premium", f"Expected 'premium', got {snapshot.budget_tier!r}"
+
+
+@pytest.mark.unit
+def test_weighted_budget_outranks_count() -> None:
+    """Weighted accumulation: a high-weight single signal beats multiple low-weight ones."""
+    driver = _make_driver_with_records(
+        [
+            {
+                "turn_count": 3,
+                "budget_signals": [
+                    {"signal": "budget", "weight": 0.3},
+                    {"signal": "budget", "weight": 0.3},
+                    {"signal": "luxury", "weight": 0.9},
+                ],
+                "preferences": [],
+                "dislikes": [],
+            }
+        ]
+    )
+    manager = _make_manager(driver)
+
+    snapshot = manager.get_persona("user_weighted")
+
+    assert snapshot.budget_tier == "luxury", (
+        f"Expected 'luxury' (weighted 0.9 > 0.6), got {snapshot.budget_tier!r}"
+    )
 
 
 @pytest.mark.unit

--- a/tests/test_reranker_material_penalty.py
+++ b/tests/test_reranker_material_penalty.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import pytest
+
+from stylemind.models.domain import RetrievedProduct
+from stylemind.models.schemas import PersonaSnapshot
+from stylemind.rag.reranker import ProductReranker
+
+
+def make_product(
+    product_id: str = "P001",
+    name: str = "Test Product",
+    aesthetics: list[str] | None = None,
+    materials: list[str] | None = None,
+    budget_tier: str = "Mid",
+    category: str = "Top",
+    brand: str = "TestBrand",
+    similarity_score: float = 0.8,
+) -> RetrievedProduct:
+    return RetrievedProduct(
+        product_id=product_id,
+        name=name,
+        description="A test product",
+        price=2000,
+        category=category,
+        brand=brand,
+        budget_tier=budget_tier,
+        aesthetics=aesthetics or [],
+        occasions=["Casual"],
+        colors=["White"],
+        seasons=["SS"],
+        materials=materials or [],
+        pairs_with=[],
+        similarity_score=similarity_score,
+    )
+
+
+@pytest.mark.unit
+def test_material_penalty_applied_when_disliked() -> None:
+    reranker = ProductReranker()
+    persona = PersonaSnapshot(
+        disliked_materials=["Polyester"],
+        confidence_score=1.0,
+    )
+    polyester_product = make_product("P_POLY", materials=["Polyester", "Cotton"], similarity_score=0.8)
+    clean_product = make_product("P_CLEAN", materials=["Cotton", "Silk"], similarity_score=0.8)
+
+    results = reranker.rerank([polyester_product, clean_product], persona, explain=True)
+    result_map = {r.product.product_id: r for r in results}
+
+    assert result_map["P_POLY"].breakdown is not None
+    assert result_map["P_POLY"].breakdown.persona_penalty > 0.0
+    assert result_map["P_CLEAN"].breakdown is not None
+    assert result_map["P_CLEAN"].breakdown.persona_penalty == 0.0
+    assert result_map["P_CLEAN"].final_score > result_map["P_POLY"].final_score
+
+
+@pytest.mark.unit
+def test_material_penalty_case_insensitive() -> None:
+    reranker = ProductReranker()
+    persona = PersonaSnapshot(
+        disliked_materials=["polyester"],
+        confidence_score=1.0,
+    )
+    product = make_product("P_POLY", materials=["Polyester"], similarity_score=0.8)
+
+    results = reranker.rerank([product], persona, explain=True)
+
+    assert results[0].breakdown is not None
+    assert results[0].breakdown.persona_penalty > 0.0
+
+
+@pytest.mark.unit
+def test_material_penalty_no_match_no_penalty() -> None:
+    reranker = ProductReranker()
+    persona = PersonaSnapshot(
+        disliked_materials=["Polyester"],
+        confidence_score=1.0,
+    )
+    product = make_product("P_COTTON", materials=["Cotton"], similarity_score=0.8)
+
+    results = reranker.rerank([product], persona, explain=True)
+
+    assert results[0].breakdown is not None
+    assert results[0].breakdown.persona_penalty == 0.0
+
+
+@pytest.mark.unit
+def test_disliked_product_penalty() -> None:
+    reranker = ProductReranker()
+    persona = PersonaSnapshot(
+        disliked_products=["P001"],
+        confidence_score=1.0,
+    )
+    disliked = make_product("P001", similarity_score=0.8)
+    normal = make_product("P002", similarity_score=0.8)
+
+    results = reranker.rerank([disliked, normal], persona, explain=True)
+    result_map = {r.product.product_id: r for r in results}
+
+    assert result_map["P001"].breakdown is not None
+    assert result_map["P001"].breakdown.persona_penalty > 0.0
+    assert result_map["P002"].breakdown is not None
+    assert result_map["P002"].breakdown.persona_penalty == 0.0
+
+
+@pytest.mark.unit
+def test_no_penalty_with_zero_confidence() -> None:
+    reranker = ProductReranker()
+    persona = PersonaSnapshot(
+        disliked_materials=["Polyester"],
+        disliked_products=["P001"],
+        confidence_score=0.0,
+    )
+    product = make_product("P001", materials=["Polyester"], similarity_score=0.8)
+
+    results = reranker.rerank([product], persona, explain=True)
+
+    assert results[0].breakdown is not None
+    assert results[0].breakdown.persona_penalty == 0.0

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -101,3 +101,23 @@ def test_pipe_separated_materials_produce_multiple_entries() -> None:
         materials = [m.strip() for m in p["material"].split("|")]
         for mat in materials:
             assert mat in MATERIAL_METADATA, f"Material {mat!r} not in MATERIAL_METADATA (product {p['product_id']})"
+
+
+@pytest.mark.unit
+def test_pipe_separated_color_palettes_valid() -> None:
+    """Products with pipe-separated color_palette should have all palettes in COLOR_PALETTE_METADATA."""
+    from seed import parse_csv  # type: ignore[import]
+
+    from data.enrichment import COLOR_PALETTE_METADATA
+
+    csv_path = Path("data/products_seed.csv")
+    products = parse_csv(csv_path)
+    pipe_products = [p for p in products if "|" in p["color_palette"]]
+    assert len(pipe_products) > 0, "Expected at least one product with pipe-separated color palettes"
+    for p in pipe_products:
+        palettes = [cp.strip() for cp in p["color_palette"].split("|")]
+        assert len(palettes) >= 2, f"Expected >= 2 palettes for {p['product_id']}, got {palettes}"
+        for cp in palettes:
+            assert cp in COLOR_PALETTE_METADATA, (
+                f"Color palette {cp!r} not in COLOR_PALETTE_METADATA (product {p['product_id']})"
+            )


### PR DESCRIPTION
## Summary
- Populate top_occasions in persona snapshot (fixes R5 spec violation)
- Read back DISLIKES->Product and penalize in reranker
- Fix material penalty — now compares actual MADE_FROM materials, not category/brand
- Return explain breakdown and product citations as structured SSE events
- Use json_schema structured output for persona extraction
- Implement weighted budget tier accumulation
- Add Neo4j uniqueness constraints for all node types
- Fix IN_COLOR to link all pipe-separated palettes

Closes #27, #29, #30, #31

## What Changed
- **Before:** R5 /persona returns empty top_occasions, material penalty is no-op, explain computed but discarded
- **After:** Full R5 compliance, material/product dislikes affect ranking, explain + citations in SSE

## Edge Cases / Future Considerations
- json_schema mode falls back to json_object if extraction LLM doesn't support it
- Weighted budget accumulation changes storage format — existing persona nodes may need migration
- Uniqueness constraints are IF NOT EXISTS — safe for existing data
- Multi-palette IN_COLOR: products now have 1-2 IN_COLOR edges (previously always 1)

## Test Plan
- [x] `make qgate` passes
- [x] `make test` passes (169 passed, 5 skipped)
- [x] `curl localhost:8000/persona/test-user` returns non-empty top_occasions after chat
- [x] POST `/chat` with `explain=true` includes `__JSON__` SSE event
- [x] `make seed` runs twice without constraint violations