### PR TITLE
security: restrict CORS origins via env var and harden .gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,12 @@ LANGFUSE_DB_PASSWORD=changeme_langfuse_db
 LANGFUSE_NEXTAUTH_SECRET=changeme_langfuse_nextauth
 LANGFUSE_SALT=changeme_langfuse_salt
 
+# ── API Security ────────────────────────────────────────────────────────────
+# Comma-separated list of allowed CORS origins.
+# Use "*" for local dev only. Always restrict in production.
+# Example: CORS_ORIGINS=https://app.example.com,https://admin.example.com
+CORS_ORIGINS=*
+
 # ── App Settings ────────────────────────────────────────────────────────────────
 # LOG_LEVEL: Python logging level (DEBUG, INFO, WARNING, ERROR)
 LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,8 @@ activemq-data/
 
 # Environments
 .env
+.env.*
+!.env.example
 .envrc
 .venv
 env/
@@ -156,6 +158,14 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Secrets / credentials
+*.key
+*.pem
+*.p12
+*.pfx
+secrets.json
+credentials.json
 
 # Spyder project settings
 .spyderproject

--- a/src/stylemind/main.py
+++ b/src/stylemind/main.py
@@ -114,12 +114,17 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    # CORS (permissive for dev; tighten in prod via env)
+    # CORS — restrict via CORS_ORIGINS env var (comma-separated).
+    # Defaults to wildcard for local dev; always set explicitly in production.
+    import os
+
+    _raw_origins = os.environ.get("CORS_ORIGINS", "*")
+    _allow_origins = [o.strip() for o in _raw_origins.split(",") if o.strip()]
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_origins=_allow_origins,
+        allow_methods=["GET", "POST"],
+        allow_headers=["Content-Type", "Accept", "Authorization"],
     )
 
     # Request-ID logging middleware


### PR DESCRIPTION
## Summary
- Closes #43: `CORS_ORIGINS` env var (comma-separated) controls allowed origins. Defaults to `*` for local dev; replaces wildcard `allow_methods`/`allow_headers` with explicit sets. Documented in `.env.example`.
- Closes #45: extend `.gitignore` with `.env.*` variants (excluding `.env.example`) and common secret file extensions (`.key`, `.pem`, `.p12`, `.pfx`) to prevent accidental future commits of rotated credential files.

## Test plan
- [ ] `CORS_ORIGINS=https://example.com` in `.env` → only that origin accepted
- [ ] No `CORS_ORIGINS` set → wildcard behavior unchanged for local dev
- [ ] `.env.production` not tracked by git (`git status` shows untracked, not modified)