### PR TITLE
fix: Python 3 except syntax, replace assert with ValueError, guard empty LLM choices

### DIFF
--- a/src/stylemind/__main__.py
+++ b/src/stylemind/__main__.py
@@ -29,7 +29,7 @@ def _wait_for_server(port: int, timeout: int = _HEALTH_TIMEOUT) -> bool:
             resp = httpx.get(url, timeout=2.0)
             if resp.status_code == 200:
                 return True
-        except httpx.ConnectError, httpx.TimeoutException, httpx.ReadError:
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.ReadError):
             pass
         time.sleep(_HEALTH_POLL_INTERVAL)
     return False

--- a/src/stylemind/config.py
+++ b/src/stylemind/config.py
@@ -115,19 +115,16 @@ class AppSettings:
     min_similarity_threshold: float
 
     def __post_init__(self) -> None:
-        assert self.log_level in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"), (
-            f"Invalid log_level: {self.log_level}"
-        )
-        assert self.vector_top_k > 0, f"vector_top_k must be > 0, got {self.vector_top_k}"
-        assert 0.0 < self.persona_decay_rate < 1.0, (
-            f"persona_decay_rate must be in (0, 1), got {self.persona_decay_rate}"
-        )
-        assert self.expected_signals_per_turn > 0.0, (
-            f"expected_signals_per_turn must be > 0, got {self.expected_signals_per_turn}"
-        )
-        assert 0.0 <= self.min_similarity_threshold <= 1.0, (
-            f"min_similarity_threshold must be in [0, 1], got {self.min_similarity_threshold}"
-        )
+        if self.log_level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+            raise ValueError(f"Invalid log_level: {self.log_level!r}")
+        if self.vector_top_k <= 0:
+            raise ValueError(f"vector_top_k must be > 0, got {self.vector_top_k}")
+        if not (0.0 < self.persona_decay_rate < 1.0):
+            raise ValueError(f"persona_decay_rate must be in (0, 1), got {self.persona_decay_rate}")
+        if self.expected_signals_per_turn <= 0.0:
+            raise ValueError(f"expected_signals_per_turn must be > 0, got {self.expected_signals_per_turn}")
+        if not (0.0 <= self.min_similarity_threshold <= 1.0):
+            raise ValueError(f"min_similarity_threshold must be in [0, 1], got {self.min_similarity_threshold}")
 
     @classmethod
     def from_env(cls) -> AppSettings:

--- a/src/stylemind/rag/generator.py
+++ b/src/stylemind/rag/generator.py
@@ -121,7 +121,10 @@ class StyleMindGenerator:
         )
 
         async for chunk in stream:
-            delta = chunk.choices[0].delta.content if chunk.choices else None
+            if not chunk.choices:
+                logger.debug("generator received chunk with empty choices array model=%s", self._config.model)
+                continue
+            delta = chunk.choices[0].delta.content
             if delta:
                 yield delta
 


### PR DESCRIPTION
## Summary
Stacks on #56 (wave-9/security).

- Closes #41: fix comma-separated `except` clause (Python 2 syntax) in `__main__.py`. This was a `SyntaxError` on Python 3.14 — the server health-poll loop was silently broken.
- Closes #52: replace all `assert` statements in `AppSettings.__post_init__` with `raise ValueError`. Asserts are stripped under `-O`/`-OO`, making validation opt-out.
- Closes #47: split the empty-`choices` guard into an explicit `continue` with a `debug` log, making suppression of heartbeat/keepalive chunks observable and avoiding a potential `AttributeError`.

## Test plan
- [ ] `uv run python -m stylemind` starts without SyntaxError on Python 3.14
- [ ] `AppSettings(log_level="INVALID")` raises `ValueError`, not `AssertionError`
- [ ] SSE stream with heartbeat chunks (choices=[]) completes without error