### PR TITLE
docs: docstrings, reranker constant annotations, env table, troubleshooting, mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,135 @@ data/
 tests/                 # pytest, asyncio_mode=auto, unit/integration/e2e/performance
 ```
 
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CHAT_API_KEY` | ✅ | — | API key for the chat LLM provider (Groq by default) |
+| `EXTRACTION_API_KEY` | ✅ | — | API key for the extraction LLM (OpenAI by default) |
+| `NEO4J_PASSWORD` | ✅ | — | Neo4j password (must match `NEO4J_AUTH` in docker-compose) |
+| `CHAT_BASE_URL` | ❌ | `https://api.groq.com/openai/v1` | OpenAI-compatible endpoint for the chat model |
+| `CHAT_MODEL` | ❌ | `llama-3.3-70b-versatile` | Model ID passed to the chat endpoint |
+| `CHAT_TEMPERATURE` | ❌ | `0.7` | Sampling temperature for chat completions |
+| `EXTRACTION_BASE_URL` | ❌ | `https://api.openai.com/v1` | OpenAI-compatible endpoint for extraction |
+| `EXTRACTION_MODEL` | ❌ | `gpt-4.1-nano` | Model ID for persona signal extraction |
+| `NEO4J_URI` | ❌ | `bolt://localhost:7687` | Neo4j bolt URI |
+| `NEO4J_USER` | ❌ | `neo4j` | Neo4j username |
+| `EMBEDDING_PROVIDER` | ❌ | `local` | `local` (sentence-transformers) or `openai` |
+| `EMBEDDING_MODEL` | ❌ | `sentence-transformers/all-MiniLM-L6-v2` | Embedding model name |
+| `EMBEDDING_DIMENSIONS` | ❌ | `384` | Embedding vector dimensions |
+| `CORS_ORIGINS` | ❌ | `*` | Comma-separated allowed CORS origins; restrict in production |
+| `LOG_LEVEL` | ❌ | `INFO` | Python logging level |
+| `VECTOR_TOP_K` | ❌ | `10` | Number of candidates retrieved per query |
+| `PERSONA_DECAY_RATE` | ❌ | `0.15` | Exponential decay rate for persona signal weights per turn |
+| `EXPECTED_SIGNALS_PER_TURN` | ❌ | `3.0` | Denominator for persona confidence calculation |
+| `MIN_SIMILARITY_THRESHOLD` | ❌ | `0.3` | Minimum cosine similarity to include a product |
+| `LANGFUSE_PUBLIC_KEY` | ❌ | — | Leave empty to disable Langfuse tracing |
+| `LANGFUSE_SECRET_KEY` | ❌ | — | Leave empty to disable Langfuse tracing |
+| `LANGFUSE_HOST` | ❌ | `http://localhost:3000` | Langfuse server URL |
+| `SERVER_PORT` | ❌ | `8000` | Port used by the CLI's embedded server |
+
+## Local Development Workflow
+
+```bash
+# 1. Install dependencies
+uv sync --dev
+
+# 2. Start Neo4j only (skip Langfuse if not needed)
+docker-compose up neo4j -d
+
+# 3. Copy and edit env
+cp .env.example .env
+# Set CHAT_API_KEY, EXTRACTION_API_KEY, NEO4J_PASSWORD at minimum
+
+# 4. Seed the graph and embed products
+uv run python scripts/seed.py
+uv run python scripts/embed.py
+
+# 5. Start the API server
+uv run uvicorn stylemind.main:app --reload
+
+# 6. Or launch the CLI (starts server automatically in background)
+uv run python -m stylemind
+```
+
+**Install pre-commit hooks** (runs ruff, pyright, and unit tests on every commit):
+
+```bash
+uv run pre-commit install
+```
+
 ## Running Tests
 
 ```bash
 make test                  # all tests
-pytest -m unit             # unit tests only
-pytest -m integration      # integration tests (requires Neo4j)
+pytest -m unit             # unit tests only (no Neo4j required)
+pytest -m integration      # integration tests (requires Neo4j running)
 pytest -m performance      # benchmarks
+```
+
+## Troubleshooting
+
+**`NEO4J_PASSWORD` not set** — the app raises `ValueError: Required environment variable 'NEO4J_PASSWORD' is not set` on startup. Copy `.env.example` to `.env` and fill in the required values.
+
+**Neo4j not ready** — the CLI polls `/health` for up to 30 s before exiting. If it times out, check `docker-compose logs neo4j` and ensure the password in `.env` matches `NEO4J_AUTH` in `docker-compose.yml`.
+
+**Empty responses / no products retrieved** — check that `scripts/embed.py` ran successfully. Products need embeddings in Neo4j before vector search works. Re-run `uv run python scripts/embed.py`.
+
+**Persona not updating** — persona updates are fire-and-forget after the SSE stream closes. Check logs for `chat persona update failed`. Common causes: Neo4j connectivity blip, or `EXTRACTION_API_KEY` missing/invalid.
+
+**CORS errors in browser** — set `CORS_ORIGINS=https://your-frontend.example.com` in `.env` (comma-separated for multiple origins).
+
+**Langfuse traces not appearing** — verify `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are set and the Langfuse server is reachable at `LANGFUSE_HOST`. The app degrades gracefully if Langfuse is unavailable.
+
+## Architecture Sub-Diagrams
+
+### RAG pipeline (per chat turn)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant API as /chat (SSE)
+    participant R as ProductRetriever
+    participant RR as ProductReranker
+    participant G as StyleMindGenerator
+    participant PM as PersonaManager
+
+    U->>API: POST /chat {message, history}
+    API->>PM: get_persona(user_id)
+    PM-->>API: PersonaSnapshot
+    API->>R: retrieve(message)
+    R-->>API: list[RetrievedProduct]
+    API->>RR: rerank(products, persona)
+    RR-->>API: list[RerankResult]
+    API->>G: stream_response(message, history, products)
+    G-->>U: SSE token stream
+    API-->>U: __JSON__ sources event
+    API-->>U: [DONE]
+    Note over API,PM: fire-and-forget persona update
+    API->>PM: update_persona(user_id, signals)
+```
+
+### Persona inference & storage
+
+```mermaid
+flowchart LR
+    Msg["User message"] --> IE["InferenceEngine\ngpt-4.1-nano"]
+    IE -->|"PersonaSignals\n(aesthetics, materials,\noccasions, budget)"| PM["PersonaManager"]
+    PM -->|"UNWIND batch writes\nin single transaction"| Neo4j[("Neo4j\nStylePersona node\n+ relationship edges")]
+    Neo4j -->|"GET_PERSONA_ALL\n(single query)"| Snap["PersonaSnapshot\n(decay-weighted)"]
+    Snap --> RAG["RAG reranking\n+ outfit building"]
+```
+
+### Outfit builder graph traversal
+
+```mermaid
+flowchart TD
+    Anchor["Anchor product\n(user expressed interest)"] -->|"PAIRS_WITH"| Candidates["Paired candidates"]
+    Candidates --> Filter["Coherence filter\n≥1 season overlap\n≥1 occasion overlap"]
+    Filter --> Rank["Persona ranking\n(aesthetic + occasion match)"]
+    Rank --> Dedup["Deduplicate by category\n(max 1 item per category)"]
+    Dedup --> Outfit["OutfitSuggestion\n(anchor + ≤3 items)"]
 ```
 
 ## Observability

--- a/src/stylemind/graph/client.py
+++ b/src/stylemind/graph/client.py
@@ -77,9 +77,6 @@ class Neo4jClient:
         self.close()
 
 
-# FastAPI dependency — client is stored once on app.state in lifespan, not created per request.
-# In main.py lifespan: app.state.neo4j = Neo4jClient(get_config().neo4j); app.state.neo4j.connect()
-# This function simply returns the shared instance — no connection lifecycle here.
 def get_neo4j_client(request: Request) -> Neo4jClient:
     """FastAPI dependency: returns Neo4jClient stored on app.state."""
     return request.app.state.neo4j  # type: ignore[no-any-return]

--- a/src/stylemind/models/domain.py
+++ b/src/stylemind/models/domain.py
@@ -45,6 +45,13 @@ class RetrievedProduct:
 
 @dataclass(frozen=True)
 class PersonaSignals:
+    """Structured signals extracted from a single chat turn by the PersonaInferenceEngine.
+
+    signal_strength reflects how much persona information was present in the turn
+    (0.0 = generic message, 1.0 = highly specific style intent).
+    sentiment_on_shown maps product_id → "positive" | "negative" | "neutral".
+    """
+
     liked_aesthetics: list[str] = field(default_factory=list)
     disliked_materials: list[str] = field(default_factory=list)
     mentioned_occasions: list[str] = field(default_factory=list)

--- a/src/stylemind/models/schemas.py
+++ b/src/stylemind/models/schemas.py
@@ -27,6 +27,8 @@ class ProductSummary(BaseModel):
 
 
 class OutfitItemSchema(BaseModel):
+    """A single paired item in an outfit suggestion, with graph-path justification."""
+
     product_id: str
     name: str
     category: str
@@ -46,7 +48,11 @@ class OutfitSuggestion(BaseModel):
 
 
 class PersonaSnapshot(BaseModel):
-    """Matches spec R5 exactly."""
+    """Current inferred style persona for a user.
+
+    All fields default to empty/zero so the first-turn snapshot is valid
+    without any prior conversation history.
+    """
 
     model_config = ConfigDict(extra="ignore")
 

--- a/src/stylemind/rag/reranker.py
+++ b/src/stylemind/rag/reranker.py
@@ -9,14 +9,23 @@ from stylemind.observability import observe
 
 logger = logging.getLogger(__name__)
 
+# Boost added per matching aesthetic between product and persona (multiplicative with confidence).
+# Capped at _PERSONA_BOOST_CAP so a single highly-matched product can't dominate infinitely.
 _PERSONA_BOOST_PER_AESTHETIC = 0.1
-_PERSONA_BOOST_CAP = 0.3
+_PERSONA_BOOST_CAP = 0.3  # max total boost from aesthetic matching (~3 aesthetic matches)
+
+# Flat boost when a product's budget_tier matches the inferred persona budget tier.
 _BUDGET_BOOST = 0.05
+
+# Penalty applied when a product contains a disliked material or is in the disliked_products list.
+# Applied per violation type (material + product_id can each contribute independently).
 _PERSONA_PENALTY = 0.15
 
 
 @dataclass(frozen=True)
 class ScoreBreakdown:
+    """Per-product score decomposition for explain-mode responses."""
+
     product_id: str
     base_score: float
     persona_boost: float
@@ -37,6 +46,8 @@ class ScoreBreakdown:
 
 @dataclass(frozen=True)
 class RerankResult:
+    """Product with its final persona-adjusted score and optional score breakdown."""
+
     product: RetrievedProduct
     final_score: float
     breakdown: ScoreBreakdown | None = None


### PR DESCRIPTION
## Summary
Stacks on #60 (wave-9/infra-dx). Final PR in the wave-9 stack.

- Closes #54: docstrings added to `PersonaSignals`, `ScoreBreakdown`, `RerankResult`, `OutfitItemSchema`, `PersonaSnapshot`; all four magic constants in `reranker.py` annotated with inline comments explaining their formula role and calibration.
- Closes #55: remove stale "Matches spec R5 exactly" docstring from `PersonaSnapshot`; remove redundant lifespan setup comment duplicated from `main.py` in `graph/client.py`.
- Closes #48: add to README — Environment Variables table (25 vars, required/optional/default), Local Development Workflow (step-by-step with docker-compose and uv), Troubleshooting guide (six common failure modes with root causes and fixes).
- Closes #50: add three focused mermaid sub-diagrams — RAG pipeline sequence diagram (per-turn request flow), persona inference & storage flowchart (extraction → batch writes → decay-weighted read), outfit builder graph traversal.

## Test plan
- [ ] `uv run pytest -m unit` → 175 passed
- [ ] README renders correctly in GitHub (mermaid diagrams display)