### PR TITLE
feat(ui): add Streamlit web UI for StyleMind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN mkdir -p /app/.cache && chown -R appuser:appuser /app
 USER appuser
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')" || exit 1
 
-EXPOSE 8000
+EXPOSE 8001
 
-CMD ["uvicorn", "stylemind.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "stylemind.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: qgate lint format type-check test test-unit test-integration test-e2e \
-       audit chat seed embed seed-and-embed setup dev health \
+       audit chat web-chat seed embed seed-and-embed setup dev health \
        db-up db-down up down clean pre-commit-install
 
 # ── Quality Gate ────────────────────────────────────────────────────────────────
@@ -56,11 +56,14 @@ seed-and-embed: seed embed
 chat:
 	uv run python -m stylemind
 
+web-chat:
+	uv run streamlit run src/stylemind/ui/app.py --server.port 8000 --server.headless true --server.fileWatcherType none
+
 dev:
-	uv run uvicorn stylemind.main:app --reload --host 127.0.0.1 --port 8000
+	uv run uvicorn stylemind.main:app --reload --host 127.0.0.1 --port 8001
 
 health:
-	@curl -sf http://localhost:8000/health && echo " OK" || echo " FAIL (is the server running?)"
+	@curl -sf http://localhost:8001/health && echo " OK" || echo " FAIL (is the server running?)"
 
 # ── Docker ──────────────────────────────────────────────────────────────────────
 
@@ -75,7 +78,7 @@ db-down:
 
 up:
 	BUILDX_BUILDER=desktop-linux docker compose up --build -d
-	@echo "App: http://localhost:8000  Neo4j: http://localhost:7474  Langfuse: https://us.cloud.langfuse.com (cloud)"
+	@echo "API: http://localhost:8001  Neo4j: http://localhost:7474  Web UI: make web-chat (localhost:8000)"
 
 down:
 	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     build: .
     restart: unless-stopped
     ports:
-      - "8000:8000"
+      - "8001:8001"
     env_file: .env
     environment:
       NEO4J_URI: bolt://neo4j:7687
@@ -44,10 +44,10 @@ services:
       sh -c "
         python scripts/seed.py &&
         python scripts/embed.py &&
-        python -m uvicorn stylemind.main:app --host 0.0.0.0 --port 8000
+        python -m uvicorn stylemind.main:app --host 0.0.0.0 --port 8001
       "
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "prompt-toolkit>=3.0",
     "httpx>=0.27",
     "langfuse>=4.0,<5.0",
+    "streamlit>=1.40",
 ]
 
 [dependency-groups]

--- a/src/stylemind/__main__.py
+++ b/src/stylemind/__main__.py
@@ -13,7 +13,7 @@ from dotenv import load_dotenv
 
 from stylemind.cli.chat import ChatCLI
 
-_DEFAULT_PORT = 8000
+_DEFAULT_PORT = 8001
 _HEALTH_TIMEOUT = 30
 _HEALTH_POLL_INTERVAL = 0.5
 

--- a/src/stylemind/ui/__init__.py
+++ b/src/stylemind/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Streamlit UI for StyleMind. See SPEC.md and app.py for entry point."""

--- a/src/stylemind/ui/app.py
+++ b/src/stylemind/ui/app.py
@@ -1,0 +1,460 @@
+"""StyleMind Streamlit UI — Direction A · Modern Boutique · Notebook · Compact.
+
+Run:  uv run streamlit run src/stylemind/ui/app.py --server.port 8000
+
+Architecture: this Streamlit process talks to the FastAPI backend on port 8001
+via httpx (streaming SSE for /chat, plain GET for /persona, /outfit). The
+FastAPI server is started in a background daemon thread on first load (same
+pattern as the Rich CLI in __main__.py).
+
+See docs/SPEC.md for the visual contract this code implements.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+
+os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+os.environ.setdefault("TQDM_DISABLE", "1")
+
+import random  # noqa: E402
+import threading  # noqa: E402
+import time  # noqa: E402
+import uuid  # noqa: E402
+from difflib import get_close_matches  # noqa: E402
+from typing import Any  # noqa: E402
+
+import httpx  # noqa: E402
+import streamlit as st  # noqa: E402
+
+from stylemind.ui.components import (  # noqa: E402
+    BASE_CSS,
+    inject_css,
+    render_brand_block,
+    render_citations,
+    render_debug_signals,
+    render_explain_table,
+    render_help_panel,
+    render_outfit_card,
+    render_persona_panel,
+    render_sidebar_persona,
+    render_signals_strip,
+    render_system_note,
+    render_top_bar,
+    render_turn_marker,
+    render_user_bubble,
+    render_welcome,
+)
+from stylemind.ui.sse_client import fetch_outfit, fetch_persona, stream_chat  # noqa: E402
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Backend server management
+
+_API_PORT = int(os.getenv("STYLEMIND_API_PORT", "8001"))
+BASE_URL = os.getenv("STYLEMIND_API", f"http://localhost:{_API_PORT}")
+
+_server_lock = threading.Lock()
+_server_started = False
+
+
+def _quiet_logging() -> None:
+    os.environ["LOG_LEVEL"] = "ERROR"
+    os.environ["TQDM_DISABLE"] = "1"
+    os.environ["TRANSFORMERS_VERBOSITY"] = "error"
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    logging.getLogger().setLevel(logging.ERROR)
+    for name in (
+        "stylemind", "langfuse", "neo4j", "sentence_transformers",
+        "httpx", "httpcore", "uvicorn", "transformers",
+    ):
+        logging.getLogger(name).setLevel(logging.ERROR)
+
+
+def _server_is_up(port: int) -> bool:
+    try:
+        resp = httpx.get(f"http://localhost:{port}/health", timeout=2.0)
+        return resp.status_code == 200
+    except httpx.ConnectError, httpx.TimeoutException, httpx.ReadError:
+        return False
+
+
+def _ensure_backend() -> None:
+    global _server_started  # noqa: PLW0603
+    if _server_started or _server_is_up(_API_PORT):
+        _server_started = True
+        return
+
+    with _server_lock:
+        if _server_started or _server_is_up(_API_PORT):
+            _server_started = True
+            return
+
+        _quiet_logging()
+
+        import uvicorn
+        from dotenv import load_dotenv
+
+        load_dotenv()
+
+        def _run() -> None:
+            uvicorn.run(
+                "stylemind.main:create_app",
+                factory=True,
+                host="0.0.0.0",
+                port=_API_PORT,
+                log_level="error",
+            )
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            if _server_is_up(_API_PORT):
+                _server_started = True
+                return
+            time.sleep(0.5)
+        st.error("FastAPI backend did not start within 60s. Check Neo4j and API keys.")
+        st.stop()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Config
+
+STARTERS_POOL = [
+    "I need something for a date night",
+    "Show me minimal summer outfits under 5k",
+    "I love the quiet luxury aesthetic",
+    "What's good for an office look?",
+    "I want casual streetwear vibes",
+    "Show me something in earthy tones",
+    "I need a wedding guest outfit",
+    "What goes well with linen pants?",
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Page setup
+
+st.set_page_config(
+    page_title="StyleMind",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+inject_css(BASE_CSS)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ensure backend is running
+
+_ensure_backend()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Session state
+
+
+def _init_state() -> None:
+    ss = st.session_state
+    ss.setdefault("user_id", f"usr-{uuid.uuid4().hex[:6]}")
+    ss.setdefault("messages", [])
+    ss.setdefault("turn_count", 0)
+    ss.setdefault("sources_log", [])
+    ss.setdefault("signals_log", [])
+    ss.setdefault("explain_log", [])
+    ss.setdefault("persona", _empty_persona())
+    ss.setdefault("explain_on", False)
+    ss.setdefault("starters", random.sample(STARTERS_POOL, 3))
+    ss.setdefault("pending_message", None)
+    ss.setdefault("product_catalog", [])
+    ss.setdefault("command_result", None)
+
+
+def _empty_persona() -> dict[str, Any]:
+    return {
+        "preferred_aesthetics": [],
+        "disliked_materials": [],
+        "disliked_products": [],
+        "budget_tier": None,
+        "top_occasions": [],
+        "color_preferences": [],
+        "confidence_score": 0.0,
+    }
+
+
+_init_state()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Product catalog (for /outfit fuzzy matching)
+
+
+def _load_product_catalog() -> None:
+    if st.session_state.product_catalog:
+        return
+    with contextlib.suppress(Exception), httpx.Client(timeout=10.0) as client:
+        resp = client.get(f"{BASE_URL}/products/names")
+        if resp.status_code == 200:
+            st.session_state.product_catalog = resp.json()
+
+
+_load_product_catalog()
+
+
+def _fuzzy_match_product(query: str) -> str | None:
+    catalog = st.session_state.product_catalog
+    q = query.lower()
+    for p in catalog:
+        if p["name"].lower() == q:
+            return p["product_id"]
+    for p in catalog:
+        if q in p["name"].lower():
+            return p["product_id"]
+    close = get_close_matches(q, [p["name"].lower() for p in catalog], n=1, cutoff=0.5)
+    if close:
+        matched = next((p for p in catalog if p["name"].lower() == close[0]), None)
+        if matched:
+            return matched["product_id"]
+    return None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Slash command handler
+
+
+def _handle_slash_command(cmd: str) -> bool:
+    """Process slash commands. Returns True if handled."""
+    low = cmd.strip().lower()
+
+    if low == "/help":
+        st.session_state.command_result = {"type": "help"}
+        return True
+
+    if low == "/persona":
+        with contextlib.suppress(Exception):
+            st.session_state.persona = fetch_persona(BASE_URL, st.session_state.user_id)
+        st.session_state.command_result = {"type": "persona", "data": st.session_state.persona}
+        return True
+
+    if low == "/debug-dev":
+        st.session_state.command_result = {"type": "debug", "data": st.session_state.signals_log}
+        return True
+
+    if low == "/clear":
+        st.session_state.messages = []
+        st.session_state.turn_count = 0
+        st.session_state.sources_log = []
+        st.session_state.signals_log = []
+        st.session_state.explain_log = []
+        st.session_state.persona = _empty_persona()
+        st.session_state.starters = random.sample(STARTERS_POOL, 3)
+        st.session_state.command_result = None
+        st.rerun()
+        return True
+
+    if low.startswith("/outfit"):
+        parts = cmd.split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            catalog = st.session_state.product_catalog
+            examples = ""
+            if catalog:
+                sample = random.sample(catalog, min(3, len(catalog)))
+                examples = " Try: " + ", ".join(f'"{p["name"]}"' for p in sample)
+            st.session_state.command_result = {"type": "note", "text": f"Usage: /outfit <product name>.{examples}"}
+            return True
+        query = parts[1].strip()
+        product_id = _fuzzy_match_product(query)
+        if not product_id:
+            catalog = st.session_state.product_catalog
+            close = get_close_matches(
+                query.lower(), [p["name"].lower() for p in catalog], n=3, cutoff=0.4,
+            )
+            suggestions = ""
+            if close:
+                names = [next(p["name"] for p in catalog if p["name"].lower() == c) for c in close]
+                suggestions = " Did you mean: " + ", ".join(f'"{n}"' for n in names) + "?"
+            st.session_state.command_result = {"type": "note", "text": f'No product matching "{query}".{suggestions}'}
+            return True
+        try:
+            outfit = fetch_outfit(BASE_URL, product_id, st.session_state.user_id)
+            st.session_state.command_result = {"type": "outfit", "data": outfit}
+        except Exception:
+            st.session_state.command_result = {"type": "note", "text": f'Could not build outfit for "{query}".'}
+        return True
+
+    return False
+
+
+def _render_command_result() -> None:
+    result = st.session_state.command_result
+    if not result:
+        return
+    t = result["type"]
+    if t == "help":
+        render_help_panel()
+    elif t == "persona":
+        render_persona_panel(result["data"])
+    elif t == "debug":
+        render_debug_signals(result["data"])
+    elif t == "outfit":
+        render_outfit_card(result["data"])
+    elif t == "note":
+        render_system_note(result["text"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sidebar — the stylist's notebook
+
+with st.sidebar:
+    render_brand_block()
+    render_sidebar_persona(
+        persona=st.session_state.persona,
+        turn=st.session_state.turn_count,
+        user_id=st.session_state.user_id,
+    )
+
+    cols = st.columns([1, 1])
+    with cols[0]:
+        if st.button("clear", key="clear_btn", use_container_width=True):
+            st.session_state.messages = []
+            st.session_state.turn_count = 0
+            st.session_state.sources_log = []
+            st.session_state.signals_log = []
+            st.session_state.explain_log = []
+            st.session_state.persona = _empty_persona()
+            st.session_state.starters = random.sample(STARTERS_POOL, 3)
+            st.rerun()
+    with cols[1]:
+        st.session_state.explain_on = st.toggle("explain", value=st.session_state.explain_on, key="explain_toggle")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main pane
+
+render_top_bar(turn_count=st.session_state.turn_count)
+
+# Empty state — welcome + starters
+if not st.session_state.messages:
+    render_welcome()
+    cols = st.columns(3, gap="small")
+    for i, starter in enumerate(st.session_state.starters):
+        with cols[i]:
+            if st.button(
+                f"0{i + 1}   {starter}   →",
+                key=f"starter_{i}",
+                use_container_width=True,
+            ):
+                st.session_state.pending_message = starter
+                st.rerun()
+
+# Render existing transcript
+for i, msg in enumerate(st.session_state.messages):
+    if msg["role"] == "user":
+        turn_idx = (i // 2) + 1
+        render_turn_marker(turn_idx)
+        render_user_bubble(msg["content"])
+    else:
+        with st.chat_message("assistant"):
+            st.markdown(
+                f'<div class="bq-msg-asst-byline">StyleMind</div><div class="bq-msg-asst-text">{msg["content"]}</div>',
+                unsafe_allow_html=True,
+            )
+            turn = i // 2
+            if turn < len(st.session_state.sources_log):
+                sources = st.session_state.sources_log[turn]
+                if sources:
+                    render_citations(sources)
+            if st.session_state.explain_on and turn < len(st.session_state.explain_log):
+                explain = st.session_state.explain_log[turn]
+                if explain:
+                    render_explain_table(explain)
+            if msg.get("outfit"):
+                render_outfit_card(msg["outfit"])
+            if turn < len(st.session_state.signals_log):
+                signals = st.session_state.signals_log[turn]
+                if signals:
+                    render_signals_strip(signals)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Command output (persists across reruns until next input)
+
+_render_command_result()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Composer
+
+placeholder = "What are we dressing for?" if not st.session_state.messages else "Anything in earth tones to swap in?"
+user_input = st.chat_input(placeholder=placeholder)
+
+message = st.session_state.pending_message or user_input
+st.session_state.pending_message = None
+
+if message:
+    if message.startswith("/"):
+        if _handle_slash_command(message):
+            st.rerun()
+    else:
+        st.session_state.command_result = None
+
+        st.session_state.messages.append({"role": "user", "content": message})
+        turn_idx = (len(st.session_state.messages) // 2) + 1
+        render_turn_marker(turn_idx)
+        render_user_bubble(message)
+
+        with st.chat_message("assistant"):
+            st.markdown(
+                '<div class="bq-msg-asst-byline">StyleMind</div>',
+                unsafe_allow_html=True,
+            )
+
+            captured: dict[str, Any] = {"sources": [], "signals": {}, "explain": []}
+
+            def text_gen():
+                yield from stream_chat(
+                    base_url=BASE_URL,
+                    user_id=st.session_state.user_id,
+                    message=message,
+                    history=st.session_state.messages[:-1],
+                    explain=st.session_state.explain_on,
+                    captured=captured,
+                )
+
+            text_placeholder = st.empty()
+            full_text = ""
+            for chunk in text_gen():
+                full_text += chunk
+                text_placeholder.markdown(
+                    f'<div class="bq-msg-asst-text">{full_text}<span class="bq-cursor">▍</span></div>',
+                    unsafe_allow_html=True,
+                )
+            text_placeholder.markdown(
+                f'<div class="bq-msg-asst-text">{full_text}</div>',
+                unsafe_allow_html=True,
+            )
+
+            sources = captured["sources"]
+            signals = captured["signals"]
+            explain = captured["explain"]
+
+            if sources:
+                render_citations(sources)
+            if st.session_state.explain_on and explain:
+                render_explain_table(explain)
+            if signals:
+                render_signals_strip(signals)
+
+        st.session_state.messages.append({"role": "assistant", "content": full_text})
+        st.session_state.sources_log.append(sources)
+        st.session_state.signals_log.append(signals)
+        st.session_state.explain_log.append(explain)
+        st.session_state.turn_count += 1
+
+        with contextlib.suppress(Exception):
+            st.session_state.persona = fetch_persona(BASE_URL, st.session_state.user_id)
+
+        st.rerun()

--- a/src/stylemind/ui/components.py
+++ b/src/stylemind/ui/components.py
@@ -1,0 +1,791 @@
+"""Reusable render helpers for the StyleMind Streamlit UI.
+
+Each helper renders a chunk of HTML via st.markdown(unsafe_allow_html=True).
+The CSS contract lives in BASE_CSS and matches SPEC.md §1–§4.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import streamlit as st
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CSS
+
+BASE_CSS = """
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+
+:root {
+  --bg: oklch(0.97 0.008 75);
+  --paper: oklch(0.99 0.005 80);
+  --ink: oklch(0.22 0.015 60);
+  --ink-soft: oklch(0.35 0.014 60);
+  --ink-faint: oklch(0.50 0.012 60);
+  --rule: oklch(0.88 0.012 70);
+  --rule-soft: oklch(0.92 0.008 70);
+  --navy: oklch(0.32 0.06 260);
+  --navy-soft: oklch(0.92 0.018 260);
+  --gold: #d4a73c;
+  --gold-soft: oklch(0.94 0.04 80);
+  --danger: oklch(0.55 0.14 30);
+}
+
+/* App-wide overrides */
+html, body, [data-testid="stAppViewContainer"] {
+  background: var(--bg) !important;
+  color: var(--ink);
+  font-family: "Inter", system-ui, sans-serif;
+  font-size: 14px;
+}
+[data-testid="stHeader"] { background: transparent; }
+[data-testid="stMain"] { padding-top: 0; }
+.block-container { max-width: 960px; padding-top: 14px; padding-bottom: 120px; }
+
+/* Sidebar */
+[data-testid="stSidebar"] {
+  background: var(--paper) !important;
+  border-right: 1px solid var(--rule);
+  width: 300px !important; min-width: 300px !important;
+}
+[data-testid="stSidebar"] > div { padding-top: 0; }
+
+/* Brand block */
+.bq-brand { padding: 18px 20px 14px; border-bottom: 1px solid var(--rule-soft);
+  display: flex; align-items: center; gap: 10px; }
+.bq-brand-mark { width: 28px; height: 28px; border-radius: 8px; background: var(--navy);
+  color: var(--gold); display: grid; place-items: center;
+  font-family: "Fraunces", serif; font-weight: 600; font-size: 16px; }
+.bq-brand-name { font-family: "Fraunces", serif; font-weight: 500;
+  font-size: 19px; letter-spacing: -0.01em; color: var(--ink); }
+.bq-brand-name em { font-style: italic; font-weight: 400; color: var(--gold); }
+.bq-brand-sub { font-size: 10.5px; color: var(--ink-faint);
+  letter-spacing: 0.08em; text-transform: uppercase; margin-top: 1px;
+  font-family: "JetBrains Mono", monospace; }
+
+/* Section labels */
+.bq-section-label { font-family: "Fraunces", serif; font-size: 11px; font-weight: 500;
+  color: var(--ink-faint); letter-spacing: 0.14em; text-transform: uppercase;
+  display: flex; align-items: center; gap: 8px; margin-top: 22px; margin-bottom: 8px; }
+.bq-section-label::after { content: ""; flex: 1; height: 1px; background: var(--rule); }
+
+/* Confidence */
+.bq-conf-row { display: flex; justify-content: space-between; align-items: baseline; }
+.bq-conf-label { font-family: "Fraunces", serif; font-size: 14px; font-style: italic; color: var(--ink); }
+.bq-conf-pct { font-family: "JetBrains Mono", monospace; font-size: 12px; color: var(--ink-faint);
+  font-feature-settings: "tnum"; }
+.bq-conf-bar { height: 4px; background: var(--rule-soft); border-radius: 2px;
+  overflow: hidden; position: relative; margin: 8px 0 4px; }
+.bq-conf-fill { position: absolute; inset: 0 auto 0 0;
+  background: linear-gradient(90deg, var(--gold), oklch(0.78 0.14 70));
+  border-radius: 2px; transition: width .4s ease; }
+.bq-conf-ticks { display: flex; justify-content: space-between;
+  font-family: "JetBrains Mono", monospace; font-size: 9.5px; color: var(--ink-faint);
+  letter-spacing: 0.04em; text-transform: uppercase; }
+
+/* Tags */
+.bq-tags { display: flex; flex-wrap: wrap; gap: 5px; }
+.bq-tag { display: inline-flex; align-items: center; gap: 5px; padding: 4px 10px;
+  background: var(--paper); border: 0.5px solid var(--rule); border-radius: 999px;
+  font-size: 12.5px; color: var(--ink); line-height: 1.4; }
+.bq-tag.gold { background: var(--gold-soft); border-color: oklch(0.88 0.07 78); color: oklch(0.38 0.08 65); }
+.bq-tag.navy { background: var(--navy-soft); border-color: oklch(0.85 0.04 260); color: var(--navy); }
+.bq-tag.muted { color: var(--ink-faint);
+  text-decoration: line-through; text-decoration-color: oklch(0.55 0.13 30 / 0.5); }
+.bq-tag-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; opacity: 0.6; }
+
+/* Budget */
+.bq-budget { display: flex; align-items: baseline; gap: 8px; }
+.bq-budget-tier { font-family: "Fraunces", serif; font-size: 18px; font-weight: 500; color: var(--ink); }
+.bq-budget-scale { display: flex; gap: 3px; margin-left: auto; }
+.bq-budget-pip { width: 18px; height: 4px; border-radius: 1px; background: var(--rule); }
+.bq-budget-pip.on { background: var(--gold); }
+
+.bq-empty-row { font-size: 12px; color: var(--ink-faint);
+  font-style: italic; font-family: "Fraunces", serif; }
+
+/* Top bar */
+.bq-main-bar { padding: 14px 0 12px; margin-bottom: 22px;
+  border-bottom: 1px solid var(--rule-soft);
+  display: flex; justify-content: space-between; align-items: center; }
+.bq-main-title { font-family: "Fraunces", serif; font-size: 15px; font-weight: 500; }
+.bq-main-title em { font-style: italic; color: var(--gold); }
+.bq-main-meta { font-family: "JetBrains Mono", monospace; font-size: 10.5px;
+  color: var(--ink-faint); letter-spacing: 0.04em; text-transform: uppercase; }
+
+/* Welcome */
+.bq-welcome { padding: 32px 0 16px; }
+.bq-welcome-eyebrow { font-family: "JetBrains Mono", monospace; font-size: 10.5px;
+  color: var(--gold); letter-spacing: 0.18em; text-transform: uppercase; margin-bottom: 14px; }
+.bq-welcome-h1 { font-family: "Fraunces", serif; font-size: 42px; font-weight: 400;
+  line-height: 1.05; letter-spacing: -0.02em; margin: 0 0 12px; color: var(--ink); }
+.bq-welcome-h1 em { font-style: italic; color: var(--gold); }
+.bq-welcome-sub { font-size: 15px; color: var(--ink-soft);
+  max-width: 480px; margin: 0 0 28px; line-height: 1.55; }
+
+/* Starter buttons (Streamlit-native, restyled) */
+.stButton > button {
+  background: var(--paper); border: 0.5px solid var(--rule);
+  border-radius: 12px; color: var(--ink); font: 400 14px Inter, sans-serif;
+  padding: 14px 18px; text-align: left; transition: all .15s ease;
+}
+.stButton > button:hover {
+  border-color: var(--gold); background: oklch(0.98 0.008 75);
+  transform: translateY(-1px); color: var(--ink);
+}
+
+/* Turn marker */
+.bq-turn-marker { font-family: "JetBrains Mono", monospace; font-size: 10px;
+  color: var(--ink-faint); letter-spacing: 0.18em; text-transform: uppercase;
+  display: flex; align-items: center; gap: 12px; margin: 20px 0 14px; }
+.bq-turn-marker::before, .bq-turn-marker::after {
+  content: ""; height: 1px; flex: 1; background: var(--rule-soft); }
+.bq-turn-marker::before { max-width: 18px; }
+
+/* User bubble */
+.bq-msg-user { align-self: flex-end; max-width: 85%; margin: 0 0 14px auto;
+  background: var(--navy); color: oklch(0.96 0.005 75);
+  padding: 12px 18px; border-radius: 18px 18px 4px 18px;
+  font-size: 14px; line-height: 1.5; width: fit-content; }
+
+/* Assistant body */
+.bq-msg-asst-byline { display: flex; align-items: center; gap: 8px;
+  font-family: "JetBrains Mono", monospace; font-size: 10px;
+  color: var(--gold); letter-spacing: 0.16em; text-transform: uppercase;
+  margin-bottom: 8px; }
+.bq-msg-asst-byline::before { content: ""; width: 14px; height: 1px; background: var(--gold); }
+.bq-msg-asst-text { font-family: "Fraunces", serif; font-size: 18px;
+  line-height: 1.5; color: var(--ink); font-weight: 400; margin-bottom: 14px; }
+.bq-cursor { color: var(--gold); animation: bq-blink 1s steps(2) infinite; }
+@keyframes bq-blink { to { opacity: 0; } }
+
+/* Citations */
+.bq-citations { border: 0.5px solid var(--rule); border-radius: 12px;
+  background: var(--paper); overflow: hidden; margin-bottom: 14px; }
+.bq-citations-hd { padding: 10px 16px; background: oklch(0.95 0.01 75);
+  border-bottom: 0.5px solid var(--rule);
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: "JetBrains Mono", monospace; font-size: 10px;
+  color: var(--ink-soft); letter-spacing: 0.14em; text-transform: uppercase; }
+.bq-cit { display: grid; grid-template-columns: 36px 1fr auto auto auto;
+  align-items: center; gap: 14px; padding: 12px 16px;
+  border-bottom: 0.5px solid var(--rule-soft); font-size: 14px; }
+.bq-cit:last-child { border-bottom: none; }
+.bq-cit:hover { background: oklch(0.98 0.008 75); }
+.bq-cit-id { font-family: "JetBrains Mono", monospace; font-size: 11px;
+  color: var(--ink-faint); letter-spacing: 0.04em; }
+.bq-cit-name { font-weight: 500; color: var(--ink);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bq-cit-name .brand { color: var(--ink-faint); font-weight: 400;
+  font-style: italic; font-family: "Fraunces", serif; margin-left: 6px; }
+.bq-cit-price { font-family: "JetBrains Mono", monospace; font-size: 13px;
+  color: var(--ink); font-feature-settings: "tnum"; }
+.bq-cit-score { width: 56px; height: 4px; background: var(--rule-soft);
+  border-radius: 2px; position: relative; overflow: hidden; }
+.bq-cit-score-fill { position: absolute; inset: 0 auto 0 0;
+  background: var(--gold); border-radius: 2px; }
+.bq-cit-score-num { font-family: "JetBrains Mono", monospace; font-size: 12px;
+  color: var(--ink-faint); width: 34px; text-align: right;
+  font-feature-settings: "tnum"; }
+
+/* Outfit */
+.bq-outfit { border: 0.5px solid var(--rule); border-radius: 14px;
+  background: var(--paper); overflow: hidden; margin-bottom: 14px; }
+.bq-outfit-hd { padding: 16px 20px 14px;
+  background: linear-gradient(180deg, oklch(0.96 0.01 75), var(--paper));
+  border-bottom: 0.5px solid var(--rule);
+  display: flex; justify-content: space-between; align-items: flex-start; }
+.bq-outfit-eyebrow { font-family: "JetBrains Mono", monospace; font-size: 9.5px;
+  color: var(--gold); letter-spacing: 0.18em; text-transform: uppercase; margin-bottom: 4px; }
+.bq-outfit-title { font-family: "Fraunces", serif; font-size: 22px; font-weight: 400;
+  letter-spacing: -0.01em; line-height: 1.15; }
+.bq-outfit-title em { font-style: italic; color: var(--gold); }
+.bq-outfit-tags { display: flex; gap: 6px; }
+.bq-outfit-stamp { padding: 4px 10px; border: 0.5px solid var(--rule);
+  border-radius: 999px; font-family: "JetBrains Mono", monospace;
+  font-size: 10px; color: var(--ink-soft); letter-spacing: 0.1em; text-transform: uppercase; }
+.bq-outfit-anchor { padding: 14px 20px; background: oklch(0.95 0.025 78);
+  border-bottom: 0.5px solid oklch(0.88 0.05 78);
+  display: flex; justify-content: space-between; align-items: center; }
+.bq-outfit-anchor-tag { font-family: "JetBrains Mono", monospace; font-size: 9.5px;
+  color: var(--gold); letter-spacing: 0.16em; text-transform: uppercase; margin-bottom: 2px; }
+.bq-outfit-anchor-name { font-family: "Fraunces", serif; font-size: 17px;
+  font-weight: 500; color: var(--ink); }
+.bq-outfit-anchor-name .brand { color: var(--ink-faint); font-style: italic;
+  font-weight: 400; margin-left: 6px; }
+.bq-outfit-anchor-price { font-family: "JetBrains Mono", monospace; font-size: 14px;
+  color: var(--ink); font-feature-settings: "tnum"; }
+.bq-outfit-item { padding: 14px 20px;
+  border-bottom: 0.5px solid var(--rule-soft);
+  display: grid; grid-template-columns: 24px 1fr auto;
+  column-gap: 14px; row-gap: 6px; align-items: baseline; }
+.bq-outfit-item:last-of-type { border-bottom: 0.5px solid var(--rule); }
+.bq-outfit-item-plus { font-family: "Fraunces", serif; font-size: 18px; color: var(--gold); }
+.bq-outfit-item-cat { font-family: "JetBrains Mono", monospace; font-size: 9.5px;
+  color: var(--ink-faint); letter-spacing: 0.14em; text-transform: uppercase; margin-bottom: 2px; }
+.bq-outfit-item-name { font-size: 14px; font-weight: 500; color: var(--ink); }
+.bq-outfit-item-name .brand { color: var(--ink-faint); font-weight: 400;
+  font-style: italic; font-family: "Fraunces", serif; margin-left: 6px; }
+.bq-outfit-item-price { grid-column: 3; grid-row: 1 / 3;
+  font-family: "JetBrains Mono", monospace; font-size: 13px;
+  color: var(--ink); font-feature-settings: "tnum"; align-self: center; }
+.bq-outfit-item-just { grid-column: 2; grid-row: 2;
+  font-size: 12.5px; color: var(--ink-soft);
+  font-family: "Fraunces", serif; font-style: italic; line-height: 1.45; }
+.bq-outfit-item-graph { grid-column: 2; grid-row: 3;
+  font-family: "JetBrains Mono", monospace; font-size: 10px; color: var(--ink-faint); }
+.bq-outfit-foot { padding: 14px 20px;
+  display: flex; justify-content: space-between; align-items: center;
+  background: oklch(0.96 0.01 75); }
+.bq-outfit-total-label { font-family: "JetBrains Mono", monospace; font-size: 10px;
+  color: var(--ink-faint); letter-spacing: 0.14em; text-transform: uppercase; }
+.bq-outfit-total-num { font-family: "Fraunces", serif; font-size: 22px;
+  font-weight: 500; color: var(--ink); font-feature-settings: "tnum"; }
+
+/* Explain */
+.bq-explain { border: 0.5px dashed var(--rule); border-radius: 10px;
+  padding: 12px 16px; background: oklch(0.97 0.012 80); margin-bottom: 14px; }
+.bq-explain-hd { font-family: "JetBrains Mono", monospace; font-size: 10px;
+  color: var(--ink-soft); letter-spacing: 0.14em; text-transform: uppercase;
+  margin-bottom: 8px; display: flex; justify-content: space-between; }
+.bq-explain-row { display: grid;
+  grid-template-columns: 50px 1fr repeat(4, 56px) 60px;
+  gap: 6px; align-items: center;
+  font-family: "JetBrains Mono", monospace; font-size: 10.5px;
+  padding: 4px 0; color: var(--ink-soft); }
+.bq-explain-row.head { color: var(--ink-faint); font-size: 9.5px;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  border-bottom: 0.5px solid var(--rule); padding-bottom: 6px; margin-bottom: 2px; }
+.bq-explain-row .num { text-align: right; font-feature-settings: "tnum"; }
+.bq-explain-row .final { color: var(--gold); font-weight: 500; }
+
+/* Signals */
+.bq-signals { border-left: 2px solid var(--gold); padding: 8px 14px;
+  background: oklch(0.97 0.014 78); border-radius: 0 6px 6px 0;
+  font-family: "JetBrains Mono", monospace; font-size: 12px;
+  color: var(--ink-soft); margin-bottom: 14px; }
+.bq-signals strong { color: var(--gold); font-weight: 500;
+  text-transform: uppercase; letter-spacing: 0.12em; font-size: 9.5px; }
+
+/* Bottom bar — fully transparent, no dark strip */
+[data-testid="stBottom"],
+[data-testid="stBottom"] > div,
+[data-testid="stBottom"] [data-testid="stBottomBlockContainer"] {
+  background: transparent !important;
+  background-color: transparent !important;
+  border-top: none !important;
+}
+[data-testid="stBottom"] > div {
+  padding: 24px 0 20px !important;
+}
+[data-testid="stBottom"] .block-container,
+[data-testid="stBottom"] [data-testid="stBottomBlockContainer"] {
+  max-width: 760px !important;
+  margin: 0 auto !important;
+}
+
+/* Composer — ChatGPT-style floating pill */
+[data-testid="stChatInput"] {
+  background: #ffffff !important;
+  background-color: #ffffff !important;
+  border: 1px solid #dbd5c9 !important;
+  border-radius: 24px !important;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+  min-height: 52px;
+}
+[data-testid="stChatInput"]:focus-within {
+  border-color: #d4a73c !important;
+  box-shadow: 0 2px 12px rgba(212,167,60,0.15);
+}
+[data-testid="stChatInput"] textarea {
+  font-family: "Inter", sans-serif !important;
+  color: #2a2620 !important;
+  font-size: 15px !important;
+  background: transparent !important;
+}
+[data-testid="stChatInput"] textarea::placeholder {
+  color: #928c84 !important;
+  font-family: "Fraunces", serif !important;
+  font-style: italic !important;
+}
+[data-testid="stChatInput"] button {
+  background: transparent !important;
+  color: #928c84 !important;
+}
+[data-testid="stChatInput"] button:hover {
+  color: #d4a73c !important;
+}
+
+/* Command output panels */
+.bq-cmd-panel { border: 0.5px solid var(--rule); border-radius: 12px;
+  background: var(--paper); padding: 16px 20px; margin-bottom: 14px; }
+.bq-cmd-title { font-family: "JetBrains Mono", monospace; font-size: 10px;
+  color: var(--gold); letter-spacing: 0.16em; text-transform: uppercase;
+  margin-bottom: 12px; display: flex; align-items: center; gap: 8px; }
+.bq-cmd-title::before { content: ""; width: 14px; height: 1px; background: var(--gold); }
+.bq-cmd-row { display: flex; justify-content: space-between; align-items: center;
+  padding: 8px 0; border-bottom: 0.5px solid var(--rule-soft); }
+.bq-cmd-row:last-child { border-bottom: none; }
+.bq-cmd-label { font-family: "Fraunces", serif; font-size: 13px; font-weight: 500;
+  color: var(--ink-soft); min-width: 120px; }
+.bq-cmd-value { font-size: 14px; color: var(--ink); }
+.bq-cmd-help-row { display: flex; gap: 12px; align-items: baseline;
+  padding: 6px 0; }
+.bq-cmd-name { font-family: "JetBrains Mono", monospace; font-size: 13px;
+  color: var(--gold); font-weight: 500; min-width: 160px; }
+.bq-cmd-desc { font-size: 13px; color: var(--ink-soft); }
+.bq-system-note { font-family: "JetBrains Mono", monospace; font-size: 11px;
+  color: var(--ink-faint); padding: 8px 14px; margin: 8px 0;
+  border-left: 2px solid var(--rule); }
+
+/* Debug signals table */
+.bq-debug-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.bq-debug-table th { font-family: "JetBrains Mono", monospace; font-size: 10px;
+  color: var(--ink-faint); letter-spacing: 0.1em; text-transform: uppercase;
+  text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--rule); }
+.bq-debug-table td { padding: 8px 8px; border-bottom: 0.5px solid var(--rule-soft);
+  font-size: 12px; color: var(--ink-soft); vertical-align: top; }
+.bq-debug-table td:first-child { font-family: "JetBrains Mono", monospace;
+  font-weight: 500; color: var(--ink); }
+
+/* Hide Streamlit footer/menu */
+#MainMenu, footer, [data-testid="stToolbar"] { visibility: hidden; }
+"""
+
+
+def inject_css(css: str) -> None:
+    st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+
+
+def _inr(n: int | None) -> str:
+    if n is None:
+        return ""
+    return "₹" + f"{n:,}"
+
+
+CONFIDENCE_LABELS = [
+    (0.20, "Learning…"),
+    (0.40, "Getting to know you"),
+    (0.60, "Building your profile"),
+    (0.80, "Personalized"),
+    (1.01, "Dialed in"),
+]
+
+BUDGET_TIERS = ["Budget", "Mid", "Premium", "Luxury"]
+
+
+def _confidence_label(score: float) -> str:
+    for cutoff, label in CONFIDENCE_LABELS:
+        if score < cutoff:
+            return label
+    return "Dialed in"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Renderers
+
+
+def render_brand_block() -> None:
+    st.markdown(
+        """
+        <div class="bq-brand">
+          <div class="bq-brand-mark">S</div>
+          <div>
+            <div class="bq-brand-name">Style<em>Mind</em></div>
+            <div class="bq-brand-sub">Personal stylist · in residence</div>
+          </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_sidebar_persona(*, persona: dict[str, Any], turn: int, user_id: str) -> None:
+    score = float(persona.get("confidence_score") or 0.0)
+    pct = round(score * 100)
+    label = _confidence_label(score)
+    aesthetics = persona.get("preferred_aesthetics") or []
+    occasions = persona.get("top_occasions") or []
+    colors = persona.get("color_preferences") or []
+    dislikes = persona.get("disliked_materials") or []
+    budget = persona.get("budget_tier")
+    budget_idx = BUDGET_TIERS.index(budget) if budget in BUDGET_TIERS else -1
+
+    parts = []
+    # Confidence
+    parts.append(
+        f"""
+        <div class="bq-section-label">Confidence</div>
+        <div class="bq-conf-row">
+          <div class="bq-conf-label">{label}</div>
+          <div class="bq-conf-pct">{pct}%</div>
+        </div>
+        <div class="bq-conf-bar"><div class="bq-conf-fill" style="width:{pct}%;"></div></div>
+        <div class="bq-conf-ticks"><span>learning</span><span>dialed in</span></div>
+        """
+    )
+    # Aesthetics
+    parts.append('<div class="bq-section-label">Aesthetics</div>')
+    if aesthetics:
+        pills = "".join(f'<span class="bq-tag gold"><span class="bq-tag-dot"></span>{a}</span>' for a in aesthetics)
+        parts.append(f'<div class="bq-tags">{pills}</div>')
+    else:
+        parts.append('<div class="bq-empty-row">— Not yet placed.</div>')
+
+    # Budget
+    parts.append('<div class="bq-section-label">Budget</div>')
+    pips = "".join(f'<div class="bq-budget-pip{" on" if i <= budget_idx else ""}"></div>' for i in range(4))
+    if budget:
+        parts.append(
+            f'<div class="bq-budget"><div class="bq-budget-tier">{budget}</div>'
+            f'<div class="bq-budget-scale">{pips}</div></div>'
+        )
+    else:
+        parts.append(
+            '<div class="bq-budget"><div class="bq-empty-row">Reading the room…</div>'
+            f'<div class="bq-budget-scale">{pips}</div></div>'
+        )
+
+    # Occasions
+    parts.append('<div class="bq-section-label">Occasions</div>')
+    if occasions:
+        pills = "".join(f'<span class="bq-tag navy">{o}</span>' for o in occasions)
+        parts.append(f'<div class="bq-tags">{pills}</div>')
+    else:
+        parts.append('<div class="bq-empty-row">— No scenes yet.</div>')
+
+    # Colors
+    if colors:
+        parts.append('<div class="bq-section-label">Colors</div>')
+        pills = "".join(f'<span class="bq-tag">{c}</span>' for c in colors)
+        parts.append(f'<div class="bq-tags">{pills}</div>')
+
+    # Dislikes
+    parts.append('<div class="bq-section-label">Crossed out</div>')
+    if dislikes:
+        pills = "".join(f'<span class="bq-tag muted">{d}</span>' for d in dislikes)
+        parts.append(f'<div class="bq-tags">{pills}</div>')
+    else:
+        parts.append('<div class="bq-empty-row">— Nothing struck through.</div>')
+
+    # Footer
+    parts.append(
+        f'<div style="margin-top:24px;padding-top:12px;border-top:1px solid var(--rule-soft);'
+        f"font-family:JetBrains Mono,monospace;font-size:10.5px;color:var(--ink-faint);"
+        f'letter-spacing:0.04em;">turn {turn:02d} · {user_id}</div>'
+    )
+
+    st.markdown(
+        f'<div style="padding:0 20px 16px;">{"".join(parts)}</div>',
+        unsafe_allow_html=True,
+    )
+
+
+def render_top_bar(*, turn_count: int) -> None:
+    if turn_count == 0:
+        meta = "session · fresh"
+    else:
+        meta = f"session · {turn_count} turn{'s' if turn_count != 1 else ''}"
+    st.markdown(
+        f"""
+        <div class="bq-main-bar">
+          <div class="bq-main-title">Today's <em>fitting</em></div>
+          <div class="bq-main-meta">{meta}</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_welcome() -> None:
+    st.markdown(
+        """
+        <div class="bq-welcome">
+          <div class="bq-welcome-eyebrow">⌁ A new fitting</div>
+          <h1 class="bq-welcome-h1">What are we <em>dressing for</em><br>today?</h1>
+          <p class="bq-welcome-sub">
+            Tell me where you're headed, what you're avoiding, who you're trying to be.
+            I'll read between the lines — no quizzes, no checkboxes.
+          </p>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_turn_marker(turn_idx: int) -> None:
+    st.markdown(
+        f'<div class="bq-turn-marker">Turn {turn_idx:02d}</div>',
+        unsafe_allow_html=True,
+    )
+
+
+def render_user_bubble(text: str) -> None:
+    safe = text.replace("<", "&lt;").replace(">", "&gt;")
+    st.markdown(f'<div class="bq-msg-user">{safe}</div>', unsafe_allow_html=True)
+
+
+def render_citations(sources: list[dict[str, Any]]) -> None:
+    rows = []
+    for s in sources:
+        score = float(s.get("score", 0))
+        rows.append(
+            '<div class="bq-cit">'
+            f'<span class="bq-cit-id">{s.get("product_id", "")}</span>'
+            f'<span class="bq-cit-name">{s.get("name", "")}'
+            f'<span class="brand">{s.get("brand", "")}</span></span>'
+            f'<span class="bq-cit-price">{_inr(s.get("price_inr"))}</span>'
+            f'<span class="bq-cit-score">'
+            f'<span class="bq-cit-score-fill" style="width:{score * 100:.0f}%;"></span></span>'
+            f'<span class="bq-cit-score-num">{score:.2f}</span>'
+            "</div>"
+        )
+    body = "".join(rows)
+    st.markdown(
+        '<div class="bq-citations">'
+        '<div class="bq-citations-hd">'
+        f"<span>{len(sources)} pulled · re-ranked for you</span>"
+        "<span>relevance</span>"
+        "</div>"
+        f"{body}"
+        "</div>",
+        unsafe_allow_html=True,
+    )
+
+
+def render_explain_table(rows: list[dict[str, Any]]) -> None:
+    body = []
+    for r in rows:
+        body.append(
+            '<div class="bq-explain-row">'
+            f'<span>{r.get("product_id", "")}</span><span></span>'
+            f'<span class="num">{r.get("base_score", 0):.2f}</span>'
+            f'<span class="num">+{r.get("persona_boost", 0):.2f}</span>'
+            f'<span class="num">−{r.get("penalty", 0):.2f}</span>'
+            f'<span class="num">+{r.get("budget_boost", 0):.2f}</span>'
+            f'<span class="num final">{r.get("final_score", 0):.2f}</span>'
+            "</div>"
+        )
+    st.markdown(
+        '<div class="bq-explain">'
+        '<div class="bq-explain-hd">'
+        "<span>Score breakdown · explain=true</span>"
+        "<span>persona-aware</span>"
+        "</div>"
+        '<div class="bq-explain-row head">'
+        '<span>id</span><span></span>'
+        '<span class="num">base</span><span class="num">+pers</span>'
+        '<span class="num">−pen</span><span class="num">+budg</span>'
+        '<span class="num">final</span>'
+        "</div>"
+        f"{''.join(body)}"
+        "</div>",
+        unsafe_allow_html=True,
+    )
+
+
+def render_outfit_card(outfit: dict[str, Any]) -> None:
+    anchor = outfit.get("anchor", {})
+    items = outfit.get("items", [])
+    occasion = outfit.get("occasion", "")
+    season = outfit.get("season", "")
+    total = (anchor.get("price_inr") or 0) + sum(it.get("price_inr", 0) for it in items)
+
+    items_html = []
+    for it in items:
+        items_html.append(
+            '<div class="bq-outfit-item">'
+            '<span class="bq-outfit-item-plus">＋</span>'
+            "<div>"
+            f'<div class="bq-outfit-item-cat">{it.get("category", "")}</div>'
+            f'<div class="bq-outfit-item-name">{it.get("name", "")}'
+            f'<span class="brand">{it.get("brand", "")}</span></div>'
+            "</div>"
+            f'<span class="bq-outfit-item-price">{_inr(it.get("price_inr"))}</span>'
+            f'<div class="bq-outfit-item-just">"{it.get("justification", "")}"</div>'
+            f'<div class="bq-outfit-item-graph">{it.get("graph_path", "")}</div>'
+            "</div>"
+        )
+
+    season_label = "summer" if season == "SS" else "winter"
+    st.markdown(
+        '<div class="bq-outfit">'
+        '<div class="bq-outfit-hd">'
+        "<div>"
+        '<div class="bq-outfit-eyebrow">A complete look · graph-built</div>'
+        f'<div class="bq-outfit-title">Around the <em>{anchor.get("name", "")}</em></div>'
+        "</div>"
+        '<div class="bq-outfit-tags">'
+        f'<span class="bq-outfit-stamp">{occasion}</span>'
+        f'<span class="bq-outfit-stamp">{season} · {season_label}</span>'
+        "</div>"
+        "</div>"
+        '<div class="bq-outfit-anchor">'
+        "<div>"
+        '<div class="bq-outfit-anchor-tag">Anchor</div>'
+        f'<div class="bq-outfit-anchor-name">{anchor.get("name", "")}'
+        f'<span class="brand">{anchor.get("brand", "")}</span></div>'
+        "</div>"
+        f'<div class="bq-outfit-anchor-price">{_inr(anchor.get("price_inr"))}</div>'
+        "</div>"
+        f"{''.join(items_html)}"
+        '<div class="bq-outfit-foot">'
+        f'<span class="bq-outfit-total-label">Complete look · {len(items) + 1} pieces</span>'
+        f'<span class="bq-outfit-total-num">{_inr(total)}</span>'
+        "</div>"
+        "</div>",
+        unsafe_allow_html=True,
+    )
+
+
+def render_signals_strip(signals: dict[str, Any]) -> None:
+    parts: list[str] = []
+    if signals.get("liked_aesthetics"):
+        parts.append("aesthetics: " + ", ".join(signals["liked_aesthetics"]))
+    if signals.get("mentioned_occasions"):
+        parts.append("occasions: " + ", ".join(signals["mentioned_occasions"]))
+    if signals.get("budget_signal"):
+        parts.append(f"budget: {signals['budget_signal']}")
+    if signals.get("color_preferences"):
+        parts.append("colors: " + ", ".join(signals["color_preferences"]))
+    if signals.get("sentiment_on_shown"):
+        s = ", ".join(f"{k}:{v}" for k, v in signals["sentiment_on_shown"].items())
+        if s:
+            parts.append(f"sentiment: {s}")
+    weight = signals.get("signal_strength")
+    weight_str = f' <span style="opacity:.6">(weight {weight:.1f})</span>' if weight is not None else ""
+    if not parts:
+        return
+    st.markdown(
+        '<div class="bq-signals">'
+        "<strong>Quietly noted</strong>"
+        f'<div style="margin-top:4px;">{"  ·  ".join(parts)}{weight_str}</div>'
+        "</div>",
+        unsafe_allow_html=True,
+    )
+
+
+def render_help_panel() -> None:
+    commands = [
+        ("/persona", "Show your current inferred style persona"),
+        ("/outfit &lt;name&gt;", "Build a complete outfit around a product"),
+        ("/debug-dev", "Show all persona signals extracted this session"),
+        ("/clear", "Clear conversation history and start fresh"),
+        ("/help", "Show this help panel"),
+    ]
+    rows = "".join(
+        f'<div class="bq-cmd-help-row">'
+        f'<span class="bq-cmd-name">{name}</span>'
+        f'<span class="bq-cmd-desc">{desc}</span>'
+        f"</div>"
+        for name, desc in commands
+    )
+    st.markdown(
+        '<div class="bq-cmd-panel">'
+        '<div class="bq-cmd-title">Available Commands</div>'
+        f"{rows}"
+        "</div>",
+        unsafe_allow_html=True,
+    )
+
+
+def render_persona_panel(persona: dict[str, Any]) -> None:
+    score = float(persona.get("confidence_score") or 0.0)
+    pct = round(score * 100)
+    label = _confidence_label(score)
+    aesthetics = persona.get("preferred_aesthetics") or []
+    occasions = persona.get("top_occasions") or []
+    colors = persona.get("color_preferences") or []
+    dislikes = persona.get("disliked_materials") or []
+    budget = persona.get("budget_tier")
+
+    def _pills(items: list[str], cls: str = "") -> str:
+        if not items:
+            return '<span style="font-style:italic;color:var(--ink-faint);">none yet</span>'
+        return " ".join(f'<span class="bq-tag {cls}">{x}</span>' for x in items)
+
+    rows = (
+        '<div class="bq-cmd-row">'
+        '<span class="bq-cmd-label">Aesthetics</span>'
+        f'<div class="bq-tags">{_pills(aesthetics, "gold")}</div>'
+        "</div>"
+        '<div class="bq-cmd-row">'
+        '<span class="bq-cmd-label">Occasions</span>'
+        f'<div class="bq-tags">{_pills(occasions, "navy")}</div>'
+        "</div>"
+        '<div class="bq-cmd-row">'
+        '<span class="bq-cmd-label">Budget</span>'
+        f'<span class="bq-cmd-value">{budget or "unknown"}</span>'
+        "</div>"
+        '<div class="bq-cmd-row">'
+        '<span class="bq-cmd-label">Colors</span>'
+        f'<div class="bq-tags">{_pills(colors)}</div>'
+        "</div>"
+        '<div class="bq-cmd-row">'
+        '<span class="bq-cmd-label">Dislikes</span>'
+        f'<div class="bq-tags">{_pills(dislikes, "muted")}</div>'
+        "</div>"
+        '<div class="bq-cmd-row">'
+        '<span class="bq-cmd-label">Confidence</span>'
+        f'<span class="bq-cmd-value">{label} ({pct}%)</span>'
+        "</div>"
+    )
+    st.markdown(
+        '<div class="bq-cmd-panel">'
+        '<div class="bq-cmd-title">Your Style Persona</div>'
+        f"{rows}"
+        "</div>",
+        unsafe_allow_html=True,
+    )
+
+
+def render_debug_signals(signals_log: list[dict[str, Any]]) -> None:
+    if not signals_log:
+        st.markdown(
+            '<div class="bq-system-note">No persona signals extracted yet. Chat first!</div>',
+            unsafe_allow_html=True,
+        )
+        return
+    rows = []
+    for idx, s in enumerate(signals_log, 1):
+        if not s:
+            continue
+        turn = s.get("turn", idx)
+        aesthetics = ", ".join(f"+{a}" for a in s.get("liked_aesthetics", [])) or "—"
+        materials = ", ".join(f"−{m}" for m in s.get("disliked_materials", [])) or "—"
+        budget = s.get("budget_signal") or "—"
+        occasions = ", ".join(s.get("mentioned_occasions", [])) or "—"
+        colors = ", ".join(s.get("color_preferences", [])) or "—"
+        brands = ", ".join(s.get("brand_mentions", [])) or "—"
+        strength = f'{s.get("signal_strength", 0):.2f}'
+        rows.append(
+            f"<tr><td>{turn}</td><td>{aesthetics}</td><td>{materials}</td>"
+            f"<td>{budget}</td><td>{occasions}</td><td>{colors}</td>"
+            f"<td>{brands}</td><td>{strength}</td></tr>"
+        )
+    st.markdown(
+        '<div class="bq-cmd-panel">'
+        '<div class="bq-cmd-title">Persona Signal Log</div>'
+        '<table class="bq-debug-table">'
+        "<thead><tr>"
+        "<th>Turn</th><th>Aesthetics</th><th>Materials</th>"
+        "<th>Budget</th><th>Occasions</th><th>Colors</th>"
+        "<th>Brands</th><th>Strength</th>"
+        "</tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody>"
+        "</table>"
+        "</div>",
+        unsafe_allow_html=True,
+    )
+
+
+def render_system_note(text: str) -> None:
+    safe = text.replace("<", "&lt;").replace(">", "&gt;")
+    st.markdown(
+        f'<div class="bq-system-note">{safe}</div>',
+        unsafe_allow_html=True,
+    )

--- a/src/stylemind/ui/components.py
+++ b/src/stylemind/ui/components.py
@@ -105,29 +105,29 @@ html, body, [data-testid="stAppViewContainer"] {
   font-style: italic; font-family: "Fraunces", serif; }
 
 /* Top bar */
-.bq-main-bar { padding: 14px 0 12px; margin-bottom: 22px;
+.bq-main-bar { padding: 18px 0 14px; margin-bottom: 28px;
   border-bottom: 1px solid var(--rule-soft);
   display: flex; justify-content: space-between; align-items: center; }
-.bq-main-title { font-family: "Fraunces", serif; font-size: 15px; font-weight: 500; }
+.bq-main-title { font-family: "Fraunces", serif; font-size: 20px; font-weight: 500; }
 .bq-main-title em { font-style: italic; color: var(--gold); }
-.bq-main-meta { font-family: "JetBrains Mono", monospace; font-size: 10.5px;
+.bq-main-meta { font-family: "JetBrains Mono", monospace; font-size: 12px;
   color: var(--ink-faint); letter-spacing: 0.04em; text-transform: uppercase; }
 
 /* Welcome */
-.bq-welcome { padding: 32px 0 16px; }
-.bq-welcome-eyebrow { font-family: "JetBrains Mono", monospace; font-size: 10.5px;
-  color: var(--gold); letter-spacing: 0.18em; text-transform: uppercase; margin-bottom: 14px; }
-.bq-welcome-h1 { font-family: "Fraunces", serif; font-size: 42px; font-weight: 400;
-  line-height: 1.05; letter-spacing: -0.02em; margin: 0 0 12px; color: var(--ink); }
+.bq-welcome { padding: 40px 0 20px; }
+.bq-welcome-eyebrow { font-family: "JetBrains Mono", monospace; font-size: 13px;
+  color: var(--gold); letter-spacing: 0.18em; text-transform: uppercase; margin-bottom: 18px; }
+.bq-welcome-h1 { font-family: "Fraunces", serif; font-size: 54px; font-weight: 400;
+  line-height: 1.08; letter-spacing: -0.02em; margin: 0 0 16px; color: var(--ink); }
 .bq-welcome-h1 em { font-style: italic; color: var(--gold); }
-.bq-welcome-sub { font-size: 15px; color: var(--ink-soft);
-  max-width: 480px; margin: 0 0 28px; line-height: 1.55; }
+.bq-welcome-sub { font-size: 18px; color: var(--ink-soft);
+  max-width: 540px; margin: 0 0 36px; line-height: 1.55; }
 
 /* Starter buttons (Streamlit-native, restyled) */
 .stButton > button {
   background: var(--paper); border: 0.5px solid var(--rule);
-  border-radius: 12px; color: var(--ink); font: 400 14px Inter, sans-serif;
-  padding: 14px 18px; text-align: left; transition: all .15s ease;
+  border-radius: 12px; color: var(--ink); font: 400 16px Inter, sans-serif;
+  padding: 16px 20px; text-align: left; transition: all .15s ease;
 }
 .stButton > button:hover {
   border-color: var(--gold); background: oklch(0.98 0.008 75);
@@ -135,27 +135,27 @@ html, body, [data-testid="stAppViewContainer"] {
 }
 
 /* Turn marker */
-.bq-turn-marker { font-family: "JetBrains Mono", monospace; font-size: 10px;
+.bq-turn-marker { font-family: "JetBrains Mono", monospace; font-size: 11px;
   color: var(--ink-faint); letter-spacing: 0.18em; text-transform: uppercase;
-  display: flex; align-items: center; gap: 12px; margin: 20px 0 14px; }
+  display: flex; align-items: center; gap: 12px; margin: 24px 0 16px; }
 .bq-turn-marker::before, .bq-turn-marker::after {
   content: ""; height: 1px; flex: 1; background: var(--rule-soft); }
 .bq-turn-marker::before { max-width: 18px; }
 
 /* User bubble */
-.bq-msg-user { align-self: flex-end; max-width: 85%; margin: 0 0 14px auto;
+.bq-msg-user { align-self: flex-end; max-width: 85%; margin: 0 0 16px auto;
   background: var(--navy); color: oklch(0.96 0.005 75);
-  padding: 12px 18px; border-radius: 18px 18px 4px 18px;
-  font-size: 14px; line-height: 1.5; width: fit-content; }
+  padding: 14px 20px; border-radius: 18px 18px 4px 18px;
+  font-size: 16px; line-height: 1.5; width: fit-content; }
 
 /* Assistant body */
 .bq-msg-asst-byline { display: flex; align-items: center; gap: 8px;
-  font-family: "JetBrains Mono", monospace; font-size: 10px;
+  font-family: "JetBrains Mono", monospace; font-size: 11px;
   color: var(--gold); letter-spacing: 0.16em; text-transform: uppercase;
-  margin-bottom: 8px; }
+  margin-bottom: 10px; }
 .bq-msg-asst-byline::before { content: ""; width: 14px; height: 1px; background: var(--gold); }
-.bq-msg-asst-text { font-family: "Fraunces", serif; font-size: 18px;
-  line-height: 1.5; color: var(--ink); font-weight: 400; margin-bottom: 14px; }
+.bq-msg-asst-text { font-family: "Fraunces", serif; font-size: 20px;
+  line-height: 1.55; color: var(--ink); font-weight: 400; margin-bottom: 16px; }
 .bq-cursor { color: var(--gold); animation: bq-blink 1s steps(2) infinite; }
 @keyframes bq-blink { to { opacity: 0; } }
 
@@ -292,16 +292,32 @@ html, body, [data-testid="stAppViewContainer"] {
   border-radius: 24px !important;
   box-shadow: 0 2px 12px rgba(0,0,0,0.08);
   min-height: 52px;
+  overflow: hidden;
+}
+/* Force ALL inner wrappers transparent so the white shows through */
+[data-testid="stChatInput"] div {
+  background: transparent !important;
+  background-color: transparent !important;
 }
 [data-testid="stChatInput"]:focus-within {
-  border-color: #d4a73c !important;
-  box-shadow: 0 2px 12px rgba(212,167,60,0.15);
+  border-color: #dbd5c9 !important;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+}
+[data-testid="stChatInput"] *:focus {
+  outline: none !important;
+  box-shadow: none !important;
+}
+[data-testid="stChatInput"] textarea:focus {
+  outline: none !important;
+  box-shadow: none !important;
+  border: none !important;
 }
 [data-testid="stChatInput"] textarea {
   font-family: "Inter", sans-serif !important;
   color: #2a2620 !important;
   font-size: 15px !important;
   background: transparent !important;
+  background-color: transparent !important;
 }
 [data-testid="stChatInput"] textarea::placeholder {
   color: #928c84 !important;
@@ -310,6 +326,7 @@ html, body, [data-testid="stAppViewContainer"] {
 }
 [data-testid="stChatInput"] button {
   background: transparent !important;
+  background-color: transparent !important;
   color: #928c84 !important;
 }
 [data-testid="stChatInput"] button:hover {

--- a/src/stylemind/ui/sse_client.py
+++ b/src/stylemind/ui/sse_client.py
@@ -1,0 +1,83 @@
+"""SSE streaming client + persona fetch.
+
+The /chat endpoint emits text chunks interleaved with __JSON__-prefixed
+structured events. We yield text for st.write_stream-style consumption and
+capture the JSON payloads into a dict supplied by the caller.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+
+
+def stream_chat(
+    *,
+    base_url: str,
+    user_id: str,
+    message: str,
+    history: list[dict[str, str]],
+    explain: bool,
+    captured: dict[str, Any],
+) -> Iterator[str]:
+    """Yield text chunks. Capture sources/signals/explain into ``captured``."""
+    payload = {
+        "user_id": user_id,
+        "message": message,
+        "history": [{"role": m["role"], "content": m["content"]} for m in history],
+        "explain": explain,
+    }
+
+    captured.setdefault("sources", [])
+    captured.setdefault("signals", {})
+    captured.setdefault("explain", [])
+
+    with (
+        httpx.Client(timeout=httpx.Timeout(60.0, connect=5.0)) as client,
+        client.stream("POST", f"{base_url}/chat", json=payload) as resp,
+    ):
+        resp.raise_for_status()
+        for raw in resp.iter_lines():
+            line = raw.strip() if isinstance(raw, str) else raw.decode().strip()
+            if not line or not line.startswith("data: "):
+                continue
+            data = line[6:]
+            if data == "[DONE]":
+                break
+            if data.startswith("__JSON__"):
+                try:
+                    evt = json.loads(data[8:])
+                except json.JSONDecodeError:
+                    continue
+                if "sources" in evt:
+                    captured["sources"].extend(evt["sources"])
+                if "signals" in evt:
+                    captured["signals"] = evt["signals"]
+                if "explain" in evt:
+                    captured["explain"].extend(evt["explain"])
+            else:
+                yield data
+
+
+def fetch_persona(base_url: str, user_id: str) -> dict[str, Any]:
+    """GET /persona/{user_id} with a small grace window for the fire-and-forget
+    persona persistence triggered by /chat[DONE]."""
+    time.sleep(0.15)
+    with httpx.Client(timeout=5.0) as client:
+        r = client.get(f"{base_url}/persona/{user_id}")
+        r.raise_for_status()
+        return r.json()
+
+
+def fetch_outfit(base_url: str, product_id: str, user_id: str) -> dict[str, Any]:
+    with httpx.Client(timeout=15.0) as client:
+        r = client.get(
+            f"{base_url}/outfit/{product_id}",
+            params={"user_id": user_id},
+        )
+        r.raise_for_status()
+        return r.json()

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,27 @@
 version = 1
 revision = 3
 requires-python = ">=3.14"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "altair"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/1e/365a9144db3254f86f1b974660b9ede1e9a38c9dc0730e4a9b1192eec5d6/altair-6.1.0.tar.gz", hash = "sha256:dda699216cf85b040d968ae5a569ad45957616811e38760a85e5118269daca67", size = 765519, upload-time = "2026-04-21T13:08:46.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/63/5dacc8d8306c715088b897a479e551bc0779fd2f0f26c97fec5e36542b4e/altair-6.1.0-py3-none-any.whl", hash = "sha256:fdf5fd939512e5b2fc4441c82dfd2635e706defbd037db0ac429ef5ddce66c3b", size = 796996, upload-time = "2026-04-21T13:08:48.549Z" },
+]
 
 [[package]]
 name = "annotated-doc"
@@ -33,12 +54,30 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
 ]
 
 [[package]]
@@ -66,6 +105,15 @@ wheels = [
 [package.optional-dependencies]
 filecache = [
     { name = "filelock" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/7b/1755ed2c6bfabd1d98b37ae73152f8dcf94aa40fee119d163c19ed484704/cachetools-7.0.6.tar.gz", hash = "sha256:e5d524d36d65703a87243a26ff08ad84f73352adbeafb1cde81e207b456aaf24", size = 37526, upload-time = "2026-04-20T19:02:23.289Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/c4/cf76242a5da1410917107ff14551764aa405a5fd10cd10cf9a5ca8fa77f4/cachetools-7.0.6-py3-none-any.whl", hash = "sha256:4e94956cfdd3086f12042cdd29318f5ced3893014f7d0d059bf3ead3f85b7f8b", size = 13976, upload-time = "2026-04-20T19:02:21.187Z" },
 ]
 
 [[package]]
@@ -290,6 +338,30 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
@@ -437,6 +509,15 @@ wheels = [
 ]
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -490,6 +571,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -607,6 +715,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
     { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
     { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/f3/257adc69a71011b4c8cda321b00f02c5bf1980ae38ffd05a58d9632d4de8/narwhals-2.20.0.tar.gz", hash = "sha256:c10994975fa7dc5a68c2cffcddbd5908fc8ebb2d463c5bab085309c0ee1f551e", size = 627848, upload-time = "2026-04-20T12:11:45.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl", hash = "sha256:16e750ea5507d4ba6e8d03455b5f93a535e0405976561baea235bca5dc9f475d", size = 449373, upload-time = "2026-04-20T12:11:43.596Z" },
 ]
 
 [[package]]
@@ -937,6 +1054,68 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
 name = "pip"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1065,6 +1244,28 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1135,6 +1336,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pydeck"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/df/4e9e7f20f8034a37c6571c93809f6d22388c39978c98d174d656c1a18fd2/pydeck-0.9.2.tar.gz", hash = "sha256:c10d9035e81ead6385264cac8d19402471f6866a15ca1f7df1400f52142bcf87", size = 5849672, upload-time = "2026-04-16T18:30:30.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/24/b30ee7d723100fd822de1bb4c0adea62f3419884a75a536f35f355d1e7c0/pydeck-0.9.2-py2.py3-none-any.whl", hash = "sha256:8213dfeacc5f6bfe6825f61c8ee34e3850e8a31fc43924379ec98edb34a75b25", size = 11305615, upload-time = "2026-04-16T18:30:28.133Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1194,6 +1408,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1213,6 +1439,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]
@@ -1248,6 +1483,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -1316,6 +1564,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
 ]
 
 [[package]]
@@ -1460,6 +1745,24 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1490,6 +1793,41 @@ wheels = [
 ]
 
 [[package]]
+name = "streamlit"
+version = "1.57.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altair" },
+    { name = "anyio" },
+    { name = "blinker" },
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "gitpython" },
+    { name = "httptools" },
+    { name = "itsdangerous" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "pyarrow" },
+    { name = "pydeck" },
+    { name = "python-multipart" },
+    { name = "requests" },
+    { name = "starlette" },
+    { name = "tenacity" },
+    { name = "toml" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+    { name = "watchdog", marker = "sys_platform != 'darwin'" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/f8/b2daf7a5f8ae15527daf94406e771bb6075e958a01c3dde9eba79dc3c9a3/streamlit-1.57.0.tar.gz", hash = "sha256:0b028d305c1a1a757071b2c9504966787602842fc8af6e873795ca58d2b4d12f", size = 8678859, upload-time = "2026-04-28T22:13:32.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/1a/3ca2293d8552bacea3e67e9600d2d1df7df4a325059769ad83d91c279595/streamlit-1.57.0-py3-none-any.whl", hash = "sha256:0d1d41972aeade5637dbb0e7f0eefa5312272f85304923d240a1b1f0475249c8", size = 9194216, upload-time = "2026-04-28T22:13:29.624Z" },
+]
+
+[[package]]
 name = "stylemind"
 version = "0.1.0"
 source = { editable = "." }
@@ -1504,6 +1842,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "sentence-transformers" },
+    { name = "streamlit" },
     { name = "transformers" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1530,6 +1869,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "sentence-transformers", specifier = ">=5.0" },
+    { name = "streamlit", specifier = ">=1.40" },
     { name = "transformers", specifier = ">=5.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
@@ -1554,6 +1894,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]
@@ -1589,6 +1938,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -1738,6 +2096,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1803,6 +2170,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add a full-featured **Streamlit web UI** (`src/stylemind/ui/`) as an alternative to the Rich CLI, providing a browser-based chat experience for StyleMind
- New SSE streaming client (`sse_client.py`) connects the Streamlit frontend to the existing FastAPI backend, parsing `__JSON__`-prefixed structured events for sources, signals, and explain data
- Custom CSS component library (`components.py`) renders styled chat bubbles, product citations, outfit cards, persona panels, explain tables, and signal strips

## What's included

### New files
- **`src/stylemind/ui/app.py`** — Main Streamlit application with auto-start of the FastAPI backend in a daemon thread, session state management, and slash command support (`/persona`, `/explain`, `/outfit`, `/help`, `/reset`, `/debug`)
- **`src/stylemind/ui/components.py`** — Reusable HTML/CSS rendering functions for the boutique-style UI (branded top bar, welcome panel, user/assistant bubbles, citation cards, outfit cards, persona sidebar, explain breakdown tables)
- **`src/stylemind/ui/sse_client.py`** — `stream_chat()` iterator that yields text chunks for `st.write_stream` while capturing structured JSON events; `fetch_persona()` and `fetch_outfit()` helpers

### Infrastructure changes
- **`pyproject.toml`** — Added `streamlit>=1.40` dependency
- **`Makefile`** — New `web-chat` target: `make web-chat` starts the Streamlit UI on port 8000
- **`Dockerfile`** — Expose port 8000 alongside 8001 for web UI mode
- **`docker-compose.yml`** — Map port 8000 for the Streamlit frontend

## How to use

```bash
# Start Neo4j + seed data (if not already done)
make db-up && make seed-and-embed

# Launch the web UI
make web-chat
# Opens at http://localhost:8000
```

The Streamlit app auto-starts the FastAPI backend on port 8001 if one isn't already running.

### Slash commands (in chat input)
| Command | Description |
|---------|-------------|
| `/persona` | Show current persona snapshot in sidebar |
| `/explain` | Toggle score-breakdown mode for reranker |
| `/outfit <product>` | Build outfit around a product name |
| `/help` | Show command reference |
| `/reset` | Clear conversation history |
| `/debug` | Toggle raw signal debug output |

## Test plan

- [ ] Run `make web-chat` and verify the UI loads at `http://localhost:8000`
- [ ] Send a chat message and confirm streaming response with product citations
- [ ] Test `/persona` shows the sidebar persona panel after a few turns
- [ ] Test `/explain` toggles score breakdown display
- [ ] Test `/outfit <product>` renders an outfit card
- [ ] Test `/help` and `/reset` commands
- [ ] Verify the existing CLI (`make chat`) and API still work unchanged