### PR TITLE
feat(ui): Streamlit web UI, docs update, and code improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH="/app/src"
 ENV HF_HOME="/app/.cache/huggingface"
 
-RUN mkdir -p /app/.cache && chown -R appuser:appuser /app
+RUN mkdir -p /app/.cache && \
+    HF_HOME=/app/.cache/huggingface python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')" && \
+    chown -R appuser:appuser /app
 
 USER appuser
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 # ── Quality Gate ────────────────────────────────────────────────────────────────
 
-qgate: lint-check format-check type-check audit
+qgate: lint-check format-check type-check audit test-unit
 
 lint-check:
 	uv run ruff check src/ tests/ scripts/
@@ -93,7 +93,8 @@ setup: pre-commit-install
 	@echo "  1. Edit .env with your API keys (CHAT_API_KEY, EXTRACTION_API_KEY)"
 	@echo "  2. make db-up              # start Neo4j"
 	@echo "  3. make seed-and-embed     # load data + embeddings"
-	@echo "  4. make chat               # start chatting"
+	@echo "  4. make web-chat           # launch web UI at http://localhost:8000"
+	@echo "     make chat               # or: terminal CLI alternative"
 
 pre-commit-install:
 	uv run pre-commit install

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@
 
 ```bash
 cp .env.example .env        # set CHAT_API_KEY (Groq), EXTRACTION_API_KEY (Groq), NEO4J_PASSWORD
-docker-compose up --build   # seed + embed run automatically on startup
+make db-up && make seed-and-embed   # start Neo4j, seed graph, build embeddings
+make web-chat                       # launch the web UI at http://localhost:8000
 ```
 
-API docs at `http://localhost:8000/docs`. Neo4j Browser at `http://localhost:7474`.
+Web UI at `http://localhost:8000`. API docs at `http://localhost:8001/docs`. Neo4j Browser at `http://localhost:7474`.
 
 ## Tech Stack
 
@@ -34,8 +35,9 @@ API docs at `http://localhost:8000/docs`. Neo4j Browser at `http://localhost:747
 | Chat LLM | Groq · Llama 3.3 70B | OpenAI-compatible SDK, swap via `CHAT_BASE_URL` |
 | Extraction LLM | Groq · Llama 3.3 70B | Structured output (JSON schema), swap via `EXTRACTION_BASE_URL` |
 | Embeddings | all-MiniLM-L6-v2 | Local, 384 dims, no API key |
-| API | FastAPI + SSE | Streaming tokens, async lifespan |
-| CLI | Rich + prompt-toolkit | Embeds FastAPI server in background thread |
+| API | FastAPI + SSE | Streaming tokens, async lifespan (port 8001) |
+| Web UI | Streamlit | Browser-based boutique chat, auto-starts API, slash commands (port 8000) |
+| CLI | Rich + prompt-toolkit | Terminal chat, embeds FastAPI in background thread |
 | Observability | Langfuse Cloud | `@observe` spans across full pipeline, token usage, persona confidence scores |
 | Packaging | Docker (two-stage, non-root) | `docker-compose up --build` starts everything |
 
@@ -49,10 +51,29 @@ API docs at `http://localhost:8000/docs`. Neo4j Browser at `http://localhost:747
 | `GET` | `/products/names` | Product catalog for autocomplete |
 | `GET` | `/health` | Liveness check (Neo4j + embedder) |
 
-## CLI
+## Chat Interfaces
+
+### Web UI (default)
 
 ```bash
-uv run python -m stylemind
+make web-chat   # opens http://localhost:8000
+```
+
+The Streamlit app auto-starts the FastAPI backend on port 8001.
+
+| Slash Command | Description |
+|---------------|-------------|
+| `/persona` | Show current persona snapshot in sidebar |
+| `/explain` | Toggle score-breakdown mode for reranker |
+| `/outfit <product>` | Build outfit around a product name |
+| `/help` | Show command reference |
+| `/reset` | Clear conversation history |
+| `/debug` | Toggle raw signal debug output |
+
+### Terminal CLI
+
+```bash
+uv run python -m stylemind   # or: make chat
 ```
 
 | Command | Action |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "httpx>=0.27",
     "langfuse>=4.0,<5.0",
     "streamlit>=1.40",
+    "orjson>=3.11.8",
 ]
 
 [dependency-groups]
@@ -62,3 +63,4 @@ markers = [
     "performance: timing benchmarks",
 ]
 testpaths = ["tests"]
+pythonpath = ["src", ".", "scripts"]

--- a/scripts/embed.py
+++ b/scripts/embed.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 
 _ROOT = Path(__file__).parent.parent
-sys.path.insert(0, str(_ROOT / "src"))
 sys.path.insert(0, str(_ROOT))
 
 from dotenv import load_dotenv  # noqa: E402

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 
 _ROOT = Path(__file__).parent.parent
-sys.path.insert(0, str(_ROOT / "src"))
 sys.path.insert(0, str(_ROOT))
 
 from dotenv import load_dotenv  # noqa: E402

--- a/src/stylemind/__main__.py
+++ b/src/stylemind/__main__.py
@@ -61,8 +61,6 @@ def main() -> None:
             print(f"ERROR: Server did not start within {_HEALTH_TIMEOUT}s.", file=sys.stderr)
             sys.exit(1)
 
-    _quiet_logging()
-
     user_id = uuid.uuid4().hex[:8]
     base_url = f"http://localhost:{port}"
 

--- a/src/stylemind/api/__init__.py
+++ b/src/stylemind/api/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from stylemind.api import chat, health, outfit, persona, products
+
+__all__ = ["chat", "health", "outfit", "persona", "products"]

--- a/src/stylemind/api/chat.py
+++ b/src/stylemind/api/chat.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import json
 import logging
 import time
 from collections.abc import AsyncGenerator
 
+import orjson
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
@@ -128,12 +128,12 @@ async def _sse_stream(
             }
             for p in reranked_products
         ]
-        yield f"data: __JSON__{json.dumps({'sources': sources_payload})}\n\n"
+        yield f"data: __JSON__{orjson.dumps({'sources': sources_payload}).decode()}\n\n"
 
     if chat_request.explain and rerank_results:
         explain_payload = [r.breakdown.to_dict() for r in rerank_results if r.breakdown is not None]
         if explain_payload:
-            yield f"data: __JSON__{json.dumps({'explain': explain_payload})}\n\n"
+            yield f"data: __JSON__{orjson.dumps({'explain': explain_payload}).decode()}\n\n"
 
     # 6b. Extract and emit persona signals BEFORE [DONE] so the CLI receives them
     extracted_signals = None
@@ -160,7 +160,7 @@ async def _sse_stream(
                     "signal_strength": extracted_signals.signal_strength,
                 }
             }
-            yield f"data: __JSON__{json.dumps(signals_payload)}\n\n"
+            yield f"data: __JSON__{orjson.dumps(signals_payload).decode()}\n\n"
         except Exception as exc:
             logger.warning("chat persona extraction failed user_id=%s error=%s", chat_request.user_id, exc)
 

--- a/src/stylemind/cli/__init__.py
+++ b/src/stylemind/cli/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from stylemind.cli.chat import ChatCLI
+
+__all__ = ["ChatCLI"]

--- a/src/stylemind/graph/__init__.py
+++ b/src/stylemind/graph/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from stylemind.graph.client import Neo4jClient, get_client_from_env
+
+__all__ = ["Neo4jClient", "get_client_from_env"]

--- a/src/stylemind/graph/queries.py
+++ b/src/stylemind/graph/queries.py
@@ -156,27 +156,36 @@ MERGE (a)-[:OVERLAPS_WITH]->(b)
 # Vector indexes (384-dim, cosine; embedding column populated by embed.py)
 # ---------------------------------------------------------------------------
 
-CREATE_PRODUCT_VECTOR_INDEX = """
+
+def create_product_vector_index(dimensions: int = 384) -> str:
+    return f"""
 CREATE VECTOR INDEX product_embeddings IF NOT EXISTS
 FOR (p:Product) ON (p.embedding)
-OPTIONS {
-  indexConfig: {
-    `vector.dimensions`: 384,
+OPTIONS {{
+  indexConfig: {{
+    `vector.dimensions`: {dimensions},
     `vector.similarity_function`: 'cosine'
-  }
-}
+  }}
+}}
 """
 
-CREATE_AESTHETIC_VECTOR_INDEX = """
+
+def create_aesthetic_vector_index(dimensions: int = 384) -> str:
+    return f"""
 CREATE VECTOR INDEX aesthetic_embeddings IF NOT EXISTS
 FOR (a:Aesthetic) ON (a.embedding)
-OPTIONS {
-  indexConfig: {
-    `vector.dimensions`: 384,
+OPTIONS {{
+  indexConfig: {{
+    `vector.dimensions`: {dimensions},
     `vector.similarity_function`: 'cosine'
-  }
-}
+  }}
+}}
 """
+
+
+# Backward-compatible constants for default 384-dim model
+CREATE_PRODUCT_VECTOR_INDEX = create_product_vector_index()
+CREATE_AESTHETIC_VECTOR_INDEX = create_aesthetic_vector_index()
 
 # ---------------------------------------------------------------------------
 # Count queries (used in tests and health checks)

--- a/src/stylemind/models/__init__.py
+++ b/src/stylemind/models/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from stylemind.models.domain import PersonaSignals, ProductRecord, RetrievedProduct
+from stylemind.models.enums import Aesthetic, BodyType, BudgetTier, Category, ColorPalette, Occasion, Season
+from stylemind.models.schemas import ChatRequest, OutfitItemSchema, OutfitSuggestion, PersonaSnapshot, ProductSummary
+
+__all__ = [
+    "Aesthetic",
+    "BodyType",
+    "BudgetTier",
+    "Category",
+    "ChatRequest",
+    "ColorPalette",
+    "Occasion",
+    "OutfitItemSchema",
+    "OutfitSuggestion",
+    "PersonaSignals",
+    "PersonaSnapshot",
+    "ProductRecord",
+    "ProductSummary",
+    "RetrievedProduct",
+    "Season",
+]

--- a/src/stylemind/outfit/__init__.py
+++ b/src/stylemind/outfit/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from stylemind.outfit.builder import OutfitBuilder
+
+__all__ = ["OutfitBuilder"]

--- a/src/stylemind/outfit/builder.py
+++ b/src/stylemind/outfit/builder.py
@@ -91,27 +91,10 @@ LIMIT 10
 # Builder
 # ---------------------------------------------------------------------------
 
-MIN_OUTFIT_ITEMS = 2  # paired items (anchor + 2-4 = 3-5 total)
 MAX_OUTFIT_ITEMS = 4
 
 
 class OutfitBuilder:
-    CATEGORY_SLOTS = [
-        "Top",
-        "Tops",
-        "Bottom",
-        "Bottoms",
-        "Footwear",
-        "Bag",
-        "Bags",
-        "Accessory",
-        "Accessories",
-        "Outerwear",
-        "Dress",
-        "Dresses",
-        "Jumpsuit",
-    ]
-
     def __init__(self, driver: Driver) -> None:
         self._driver = driver
 

--- a/src/stylemind/persona/__init__.py
+++ b/src/stylemind/persona/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from stylemind.persona.inference import PersonaInferenceEngine
+from stylemind.persona.manager import PersonaManager
+
+__all__ = ["PersonaInferenceEngine", "PersonaManager"]

--- a/src/stylemind/persona/inference.py
+++ b/src/stylemind/persona/inference.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import json
 import logging
 
+import orjson
 from openai import OpenAI
 
 from stylemind.config import ExtractionLLMConfig
@@ -66,6 +66,7 @@ class PersonaInferenceEngine:
     def __init__(self, config: ExtractionLLMConfig) -> None:
         self._client = OpenAI(base_url=config.base_url, api_key=config.api_key)
         self._model = config.model
+        self._supports_json_schema: bool | None = None
 
     @observe(name="extract_signals")
     def extract_signals(
@@ -104,36 +105,46 @@ class PersonaInferenceEngine:
             else:
                 user_content = message
 
-            try:
+            messages = [
+                {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
+                {"role": "user", "content": user_content},
+            ]
+
+            if self._supports_json_schema is False:
                 response = self._client.chat.completions.create(
                     model=self._model,
-                    messages=[
-                        {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
-                        {"role": "user", "content": user_content},
-                    ],
-                    response_format={
-                        "type": "json_schema",
-                        "json_schema": {
-                            "name": "PersonaSignals",
-                            "schema": _PERSONA_JSON_SCHEMA,
-                            "strict": True,
-                        },
-                    },
-                    temperature=0,
-                )
-            except Exception:
-                response = self._client.chat.completions.create(
-                    model=self._model,
-                    messages=[
-                        {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
-                        {"role": "user", "content": user_content},
-                    ],
+                    messages=messages,
                     response_format={"type": "json_object"},
                     temperature=0,
                 )
+            else:
+                try:
+                    response = self._client.chat.completions.create(
+                        model=self._model,
+                        messages=messages,
+                        response_format={
+                            "type": "json_schema",
+                            "json_schema": {
+                                "name": "PersonaSignals",
+                                "schema": _PERSONA_JSON_SCHEMA,
+                                "strict": True,
+                            },
+                        },
+                        temperature=0,
+                    )
+                    self._supports_json_schema = True
+                except Exception:
+                    logger.info("json_schema not supported by provider, falling back to json_object")
+                    self._supports_json_schema = False
+                    response = self._client.chat.completions.create(
+                        model=self._model,
+                        messages=messages,
+                        response_format={"type": "json_object"},
+                        temperature=0,
+                    )
 
             raw_content = response.choices[0].message.content or "{}"
-            data = json.loads(raw_content)
+            data = orjson.loads(raw_content)
             signals = PersonaSignals(**data)
 
             if hasattr(response, "usage") and response.usage is not None:

--- a/src/stylemind/persona/manager.py
+++ b/src/stylemind/persona/manager.py
@@ -186,15 +186,18 @@ class PersonaManager:
         decayed_occasions.sort(key=lambda x: x[1], reverse=True)
         top_occasions = [name for name, _ in decayed_occasions[:3]]
 
-        # Budget tier: weighted accumulation
+        # Budget tier: weighted accumulation (entries stored as "signal:weight" strings)
         budget_weights: dict[str, float] = {}
         for entry in budget_signals:
-            if isinstance(entry, dict):
-                sig = entry.get("signal", "")
-                w = float(entry.get("weight", 1.0))
+            entry_str = str(entry)
+            if ":" in entry_str:
+                sig, w_str = entry_str.rsplit(":", 1)
+                try:
+                    w = float(w_str)
+                except ValueError:
+                    sig, w = entry_str, 1.0
             else:
-                sig = str(entry)
-                w = 1.0
+                sig, w = entry_str, 1.0
             budget_weights[sig] = budget_weights.get(sig, 0.0) + w
         budget_tier: str | None = max(budget_weights, key=lambda k: budget_weights[k]) if budget_weights else None
 
@@ -290,13 +293,13 @@ class PersonaManager:
                         },
                     )
 
-                # Budget signal — stored as plain string; Neo4j can't store Map in property arrays
+                # Budget signal — encoded as "signal:weight" string; Neo4j can't store Maps in property arrays
                 if signals.budget_signal:
                     tx.run(
                         SET_BUDGET_SIGNAL,
                         {
                             "user_id": user_id,
-                            "budget_entry": signals.budget_signal,
+                            "budget_entry": f"{signals.budget_signal}:{weight:.2f}",
                         },
                     )
 

--- a/src/stylemind/rag/__init__.py
+++ b/src/stylemind/rag/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from stylemind.rag.embedder import Embedder, LocalEmbedder, OpenAIEmbedder, get_embedder
+from stylemind.rag.generator import StyleMindGenerator
+from stylemind.rag.reranker import ProductReranker, RerankResult, ScoreBreakdown
+from stylemind.rag.retriever import ProductRetriever
+
+__all__ = [
+    "Embedder",
+    "LocalEmbedder",
+    "OpenAIEmbedder",
+    "ProductReranker",
+    "ProductRetriever",
+    "RerankResult",
+    "ScoreBreakdown",
+    "StyleMindGenerator",
+    "get_embedder",
+]

--- a/src/stylemind/rag/embedder.py
+++ b/src/stylemind/rag/embedder.py
@@ -29,6 +29,7 @@ class LocalEmbedder:
     def __init__(self, model_name: str = "sentence-transformers/all-MiniLM-L6-v2", *, lazy: bool = False) -> None:
         self._model_name = model_name
         self._model = None
+        self._dimensions: int | None = None
         if not lazy:
             self._get_model()
 
@@ -38,6 +39,10 @@ class LocalEmbedder:
 
             logger.info("Loading sentence-transformers model=%s", self._model_name)
             self._model = SentenceTransformer(self._model_name)
+            dim_fn = (
+                getattr(self._model, "get_embedding_dimension", None) or self._model.get_sentence_embedding_dimension
+            )
+            self._dimensions = dim_fn()
         return self._model
 
     def embed_query(self, text: str) -> list[float]:
@@ -52,7 +57,9 @@ class LocalEmbedder:
 
     @property
     def dimensions(self) -> int:
-        return 384
+        if self._dimensions is None:
+            self._get_model()
+        return self._dimensions  # type: ignore[return-value]
 
 
 class OpenAIEmbedder:
@@ -108,5 +115,7 @@ def get_embedder(config=None) -> LocalEmbedder | OpenAIEmbedder:
             model=config.model_name,
             dimensions=config.dimensions,
         )
-    else:  # local (default)
+    elif config.provider == "local":
         return LocalEmbedder(model_name=config.model_name)
+    else:
+        raise ValueError(f"Invalid EMBEDDING_PROVIDER: {config.provider!r}. Valid options: 'local', 'openai'")

--- a/src/stylemind/rag/reranker.py
+++ b/src/stylemind/rag/reranker.py
@@ -63,9 +63,6 @@ class ProductReranker:
     ranking is identical to pure vector similarity ordering.
     """
 
-    def __init__(self, persona_weight: float = 0.3) -> None:
-        self._persona_weight = persona_weight
-
     @observe(name="rerank")
     def rerank(
         self,
@@ -84,6 +81,16 @@ class ProductReranker:
             list[RerankResult] sorted by final_score descending.
         """
         confidence = persona.confidence_score
+
+        # Hard-filter disliked materials before scoring to avoid wasted computation
+        if confidence > 0.0 and persona.disliked_materials:
+            disliked_lower = {m.lower() for m in persona.disliked_materials}
+            before_count = len(candidates)
+            candidates = [c for c in candidates if not ({m.lower() for m in c.materials} & disliked_lower)]
+            filtered = before_count - len(candidates)
+            if filtered:
+                logger.info("reranker filtered_disliked_materials=%d", filtered)
+
         results: list[RerankResult] = []
 
         for candidate in candidates:
@@ -96,15 +103,10 @@ class ProductReranker:
                 raw_boost = len(matched) * _PERSONA_BOOST_PER_AESTHETIC * confidence
                 persona_boost = min(raw_boost, _PERSONA_BOOST_CAP)
 
-            # --- persona penalty ---
+            # --- persona penalty (disliked products only; materials already filtered) ---
             persona_penalty = 0.0
-            if confidence > 0.0:
-                disliked_lower = {m.lower() for m in persona.disliked_materials}
-                candidate_materials_lower = {m.lower() for m in candidate.materials}
-                if candidate_materials_lower & disliked_lower:
-                    persona_penalty += _PERSONA_PENALTY * confidence
-                if persona.disliked_products and candidate.product_id in persona.disliked_products:
-                    persona_penalty += _PERSONA_PENALTY * confidence
+            if confidence > 0.0 and persona.disliked_products and candidate.product_id in persona.disliked_products:
+                persona_penalty = _PERSONA_PENALTY * confidence
 
             # --- budget boost ---
             budget_boost = 0.0
@@ -140,19 +142,6 @@ class ProductReranker:
                 budget_boost,
                 final_score,
             )
-
-        # Hard-filter products containing disliked materials
-        if confidence > 0.0 and persona.disliked_materials:
-            disliked_lower = {m.lower() for m in persona.disliked_materials}
-            before_count = len(results)
-            results = [
-                r
-                for r in results
-                if not ({m.lower() for m in r.product.materials} & disliked_lower)
-            ]
-            filtered = before_count - len(results)
-            if filtered:
-                logger.info("reranker filtered_disliked_materials=%d", filtered)
 
         results.sort(key=lambda r: r.final_score, reverse=True)
         logger.info("reranker reranked candidate_count=%d confidence=%.2f", len(results), confidence)

--- a/src/stylemind/ui/app.py
+++ b/src/stylemind/ui/app.py
@@ -67,8 +67,14 @@ def _quiet_logging() -> None:
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
     logging.getLogger().setLevel(logging.ERROR)
     for name in (
-        "stylemind", "langfuse", "neo4j", "sentence_transformers",
-        "httpx", "httpcore", "uvicorn", "transformers",
+        "stylemind",
+        "langfuse",
+        "neo4j",
+        "sentence_transformers",
+        "httpx",
+        "httpcore",
+        "uvicorn",
+        "transformers",
     ):
         logging.getLogger(name).setLevel(logging.ERROR)
 
@@ -271,7 +277,10 @@ def _handle_slash_command(cmd: str) -> bool:
         if not product_id:
             catalog = st.session_state.product_catalog
             close = get_close_matches(
-                query.lower(), [p["name"].lower() for p in catalog], n=3, cutoff=0.4,
+                query.lower(),
+                [p["name"].lower() for p in catalog],
+                n=3,
+                cutoff=0.4,
             )
             suggestions = ""
             if close:

--- a/src/stylemind/ui/components.py
+++ b/src/stylemind/ui/components.py
@@ -579,7 +579,7 @@ def render_explain_table(rows: list[dict[str, Any]]) -> None:
     for r in rows:
         body.append(
             '<div class="bq-explain-row">'
-            f'<span>{r.get("product_id", "")}</span><span></span>'
+            f"<span>{r.get('product_id', '')}</span><span></span>"
             f'<span class="num">{r.get("base_score", 0):.2f}</span>'
             f'<span class="num">+{r.get("persona_boost", 0):.2f}</span>'
             f'<span class="num">−{r.get("penalty", 0):.2f}</span>'
@@ -594,7 +594,7 @@ def render_explain_table(rows: list[dict[str, Any]]) -> None:
         "<span>persona-aware</span>"
         "</div>"
         '<div class="bq-explain-row head">'
-        '<span>id</span><span></span>'
+        "<span>id</span><span></span>"
         '<span class="num">base</span><span class="num">+pers</span>'
         '<span class="num">−pen</span><span class="num">+budg</span>'
         '<span class="num">final</span>'
@@ -702,10 +702,7 @@ def render_help_panel() -> None:
         for name, desc in commands
     )
     st.markdown(
-        '<div class="bq-cmd-panel">'
-        '<div class="bq-cmd-title">Available Commands</div>'
-        f"{rows}"
-        "</div>",
+        f'<div class="bq-cmd-panel"><div class="bq-cmd-title">Available Commands</div>{rows}</div>',
         unsafe_allow_html=True,
     )
 
@@ -752,10 +749,7 @@ def render_persona_panel(persona: dict[str, Any]) -> None:
         "</div>"
     )
     st.markdown(
-        '<div class="bq-cmd-panel">'
-        '<div class="bq-cmd-title">Your Style Persona</div>'
-        f"{rows}"
-        "</div>",
+        f'<div class="bq-cmd-panel"><div class="bq-cmd-title">Your Style Persona</div>{rows}</div>',
         unsafe_allow_html=True,
     )
 
@@ -778,7 +772,7 @@ def render_debug_signals(signals_log: list[dict[str, Any]]) -> None:
         occasions = ", ".join(s.get("mentioned_occasions", [])) or "—"
         colors = ", ".join(s.get("color_preferences", [])) or "—"
         brands = ", ".join(s.get("brand_mentions", [])) or "—"
-        strength = f'{s.get("signal_strength", 0):.2f}'
+        strength = f"{s.get('signal_strength', 0):.2f}"
         rows.append(
             f"<tr><td>{turn}</td><td>{aesthetics}</td><td>{materials}</td>"
             f"<td>{budget}</td><td>{occasions}</td><td>{colors}</td>"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -413,3 +413,75 @@ def test_chat_when_generator_is_none():
 
     assert response.status_code == 200
     assert "not available" in response.text.lower() or "StyleMind generator not available" in response.text
+
+
+# ---------------------------------------------------------------------------
+# API error path tests (#75)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_chat_stream_error_mid_response():
+    """LLM stream raises mid-response → error event sent and stream ends with [DONE]."""
+
+    async def _failing_stream(*args, **kwargs):
+        yield "Start"
+        raise RuntimeError("LLM connection lost")
+
+    app = _make_app_with_mocks()
+    app.state.generator.stream_response = MagicMock(side_effect=_failing_stream)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.post("/chat", json={"user_id": "u1", "message": "hello"})
+
+    assert response.status_code == 200
+    payloads = _parse_sse_data(response)
+    assert payloads[-1] == "[DONE]"
+    assert any("error" in p.lower() for p in payloads)
+
+
+@pytest.mark.unit
+def test_chat_retriever_failure_still_responds():
+    """Retriever throws → chat still returns a response and ends with [DONE]."""
+    app = _make_app_with_mocks(stream_chunks=["Fallback response"])
+    app.state.retriever.retrieve = MagicMock(side_effect=RuntimeError("Neo4j unavailable"))
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.post("/chat", json={"user_id": "u1", "message": "what to wear?"})
+
+    assert response.status_code == 200
+    payloads = _parse_sse_data(response)
+    assert payloads[-1] == "[DONE]"
+    assert any("Fallback response" in p for p in payloads)
+
+
+@pytest.mark.unit
+def test_chat_persona_inference_failure_still_responds():
+    """Persona inference failure → chat still succeeds, no persona signals emitted."""
+    app = _make_app_with_mocks(stream_chunks=["Hello"])
+    app.state.inference_engine.extract_signals = MagicMock(side_effect=RuntimeError("Extraction failed"))
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.post("/chat", json={"user_id": "u1", "message": "show me dresses"})
+
+    assert response.status_code == 200
+    payloads = _parse_sse_data(response)
+    assert payloads[-1] == "[DONE]"
+    signals_events = [p for p in payloads if "__JSON__" in p and "signals" in p]
+    assert len(signals_events) == 0
+
+
+@pytest.mark.unit
+def test_chat_empty_retrieval_still_streams():
+    """Retriever returns empty results → response still streams and completes."""
+    app = _make_app_with_mocks(stream_chunks=["No products found, but here's advice"])
+    app.state.retriever.retrieve = MagicMock(return_value=[])
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.post("/chat", json={"user_id": "u1", "message": "hello"})
+
+    assert response.status_code == 200
+    payloads = _parse_sse_data(response)
+    assert payloads[-1] == "[DONE]"
+    sources_events = [p for p in payloads if "__JSON__" in p and "sources" in p]
+    assert len(sources_events) == 0

--- a/tests/test_csv_parser.py
+++ b/tests/test_csv_parser.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import pytest
 
-# Ensure scripts/ and project root are importable during tests.
-_ROOT = Path(__file__).parent.parent
-sys.path.insert(0, str(_ROOT / "src"))
-sys.path.insert(0, str(_ROOT))
-sys.path.insert(0, str(_ROOT / "scripts"))
-
-_CSV_PATH = _ROOT / "data" / "products_seed.csv"
+_CSV_PATH = Path(__file__).parent.parent / "data" / "products_seed.csv"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -90,7 +90,7 @@ def test_embedding_latency_under_500ms() -> None:
 @pytest.mark.performance
 def test_reranker_latency_under_200ms() -> None:
     """ProductReranker.rerank with 10 products and a persona must complete in < 200ms."""
-    reranker = ProductReranker(persona_weight=0.3)
+    reranker = ProductReranker()
     products = _make_10_products()
     persona = _make_persona_snapshot()
 

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -363,8 +363,7 @@ def test_persona_5_turn_evolution():
     # ---- execute_query interceptor (get_persona single read) ----
     def execute_query_side_effect(query: str, params: dict, database_: str = "neo4j") -> MagicMock:
         prefs = [
-            {"aesthetic": n, "weight": v["weight"], "last_seen": v["last_seen"]}
-            for n, v in stored_aesthetics.items()
+            {"aesthetic": n, "weight": v["weight"], "last_seen": v["last_seen"]} for n, v in stored_aesthetics.items()
         ]
         rec = MagicMock()
         rec.data.return_value = {

--- a/tests/test_persona_inference.py
+++ b/tests/test_persona_inference.py
@@ -227,3 +227,60 @@ def test_shown_products_included_in_context() -> None:
     user_msg = next((m["content"] for m in messages if m["role"] == "user"), "")
     assert "P001" in user_msg
     assert "P002" in user_msg
+
+
+# ---------------------------------------------------------------------------
+# json_schema capability caching (#68)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_json_schema_fallback_extracts_correct_signals() -> None:
+    """Fallback to json_object still extracts signals correctly (#73)."""
+    engine = _make_engine()
+    expected_data = _full_signals(
+        liked_aesthetics=["Quiet Luxury"],
+        budget_signal="premium",
+        signal_strength=0.8,
+    )
+    response = _mock_response(expected_data)
+
+    call_count = 0
+
+    def side_effect(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        rf = kwargs.get("response_format", {})
+        if rf.get("type") == "json_schema":
+            raise RuntimeError("json_schema not supported")
+        return response
+
+    with patch.object(engine._client.chat.completions, "create", side_effect=side_effect):
+        signals = engine.extract_signals("I like understated luxury", [], [])
+        assert call_count == 2  # json_schema attempt + json_object fallback
+        assert engine._supports_json_schema is False
+        assert signals.liked_aesthetics == ["Quiet Luxury"]
+        assert signals.budget_signal == "premium"
+        assert signals.signal_strength == pytest.approx(0.8)
+
+        call_count = 0
+        signals2 = engine.extract_signals("second call", [], [])
+        assert call_count == 1  # only json_object, no wasted attempt
+        assert signals2.liked_aesthetics == ["Quiet Luxury"]
+
+
+@pytest.mark.unit
+def test_json_schema_success_caches_support() -> None:
+    """When json_schema succeeds, the flag is set to True and reused."""
+    engine = _make_engine()
+    response = _mock_response(_full_signals(signal_strength=0.5))
+
+    with patch.object(engine._client.chat.completions, "create", return_value=response) as mock_create:
+        engine.extract_signals("first call", [], [])
+        assert engine._supports_json_schema is True
+
+        engine.extract_signals("second call", [], [])
+        # Both calls should use json_schema format
+        for call in mock_create.call_args_list:
+            rf = call[1].get("response_format", {})
+            assert rf.get("type") == "json_schema"

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -125,10 +125,10 @@ def test_budget_accumulation() -> None:
     data = _make_full_record(
         turn_count=4,
         budget_signals=[
-            {"signal": "premium", "weight": 0.8},
-            {"signal": "premium", "weight": 0.6},
-            {"signal": "luxury", "weight": 0.9},
-            {"signal": "premium", "weight": 0.7},
+            "premium:0.80",
+            "premium:0.60",
+            "luxury:0.90",
+            "premium:0.70",
         ],
     )
     snapshot = _make_manager(_make_driver_with_records([data])).get_persona("user_budget")
@@ -141,9 +141,9 @@ def test_weighted_budget_outranks_count() -> None:
     data = _make_full_record(
         turn_count=3,
         budget_signals=[
-            {"signal": "budget", "weight": 0.3},
-            {"signal": "budget", "weight": 0.3},
-            {"signal": "luxury", "weight": 0.9},
+            "budget:0.30",
+            "budget:0.30",
+            "luxury:0.90",
         ],
     )
     snapshot = _make_manager(_make_driver_with_records([data])).get_persona("user_weighted")
@@ -248,7 +248,9 @@ def test_occasion_decay_ordering() -> None:
 def test_update_persona_uses_session_transaction() -> None:
     """update_persona opens a session and begins a transaction (atomic writes)."""
     driver = _make_update_driver(turn_count=1)
-    _make_manager(driver).update_persona("user_001", PersonaSignals(liked_aesthetics=["Quiet Luxury"], signal_strength=0.8))
+    _make_manager(driver).update_persona(
+        "user_001", PersonaSignals(liked_aesthetics=["Quiet Luxury"], signal_strength=0.8)
+    )
 
     driver.session.assert_called_once_with(database="neo4j")
     mock_session = driver.session.return_value.__enter__.return_value
@@ -325,7 +327,7 @@ def test_update_persona_negative_sentiment_writes_disliked_product() -> None:
 
 @pytest.mark.unit
 def test_update_persona_budget_signal_stored() -> None:
-    """budget_signal triggers the SET_BUDGET_SIGNAL tx.run call."""
+    """budget_signal triggers the SET_BUDGET_SIGNAL tx.run call with encoded format."""
     driver = _make_update_driver(turn_count=1)
     _make_manager(driver).update_persona("user_luxury", PersonaSignals(budget_signal="luxury", signal_strength=0.7))
 
@@ -334,6 +336,58 @@ def test_update_persona_budget_signal_stored() -> None:
 
     budget_calls = [c for c in mock_tx.run.call_args_list if "budget_entry" in str(c)]
     assert len(budget_calls) == 1
+    params = budget_calls[0][0][1]
+    assert params["budget_entry"] == "luxury:0.70"
+
+
+@pytest.mark.unit
+def test_budget_signal_write_read_round_trip() -> None:
+    """Budget signal written by update_persona can be correctly parsed by get_persona (#69, #74)."""
+    write_driver = _make_update_driver(turn_count=1)
+    manager = _make_manager(write_driver)
+    manager.update_persona("user_rt", PersonaSignals(budget_signal="premium", signal_strength=0.85))
+
+    mock_session = write_driver.session.return_value.__enter__.return_value
+    mock_tx = mock_session.begin_transaction.return_value.__enter__.return_value
+    budget_calls = [c for c in mock_tx.run.call_args_list if "budget_entry" in str(c)]
+    written_entry = budget_calls[0][0][1]["budget_entry"]
+
+    read_driver = _make_driver_with_records(
+        [
+            _make_full_record(
+                turn_count=1,
+                budget_signals=[written_entry],
+            )
+        ]
+    )
+    snapshot = _make_manager(read_driver).get_persona("user_rt")
+    assert snapshot.budget_tier == "premium"
+
+
+@pytest.mark.unit
+def test_budget_signal_round_trip_preserves_weight_ranking() -> None:
+    """Two budget signals written with different weights → higher total weight wins on read."""
+    write_driver = _make_update_driver(turn_count=1)
+    manager = _make_manager(write_driver)
+
+    manager.update_persona("user_w", PersonaSignals(budget_signal="mid", signal_strength=0.3))
+    manager.update_persona("user_w", PersonaSignals(budget_signal="luxury", signal_strength=0.95))
+
+    mock_session = write_driver.session.return_value.__enter__.return_value
+    mock_tx = mock_session.begin_transaction.return_value.__enter__.return_value
+    budget_calls = [c for c in mock_tx.run.call_args_list if "budget_entry" in str(c)]
+    written_entries = [c[0][1]["budget_entry"] for c in budget_calls]
+
+    read_driver = _make_driver_with_records(
+        [
+            _make_full_record(
+                turn_count=2,
+                budget_signals=written_entries,
+            )
+        ]
+    )
+    snapshot = _make_manager(read_driver).get_persona("user_w")
+    assert snapshot.budget_tier == "luxury"
 
 
 @pytest.mark.unit
@@ -420,6 +474,7 @@ def test_retry_retries_on_transient_failure() -> None:
 @pytest.mark.unit
 def test_retry_raises_after_exhaustion() -> None:
     """_retry re-raises the last exception when all attempts fail."""
+
     def fn() -> None:
         raise ValueError("permanent error")
 

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,16 +1,8 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import pytest
-
-# Ensure scripts/ and project root are importable during tests.
-_ROOT = Path(__file__).parent.parent
-sys.path.insert(0, str(_ROOT / "src"))
-sys.path.insert(0, str(_ROOT))
-sys.path.insert(0, str(_ROOT / "scripts"))
-
 
 # ---------------------------------------------------------------------------
 # Unit tests — no Neo4j required

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/87/87a014f045b77c6de5c8527b0757fe644417b184e5367db977236a141602/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6464b30f46692d6c7f65d4a0e0450d81dd29de3afc1bb515653973d01c2cd6e", size = 5685673, upload-time = "2026-03-11T00:12:56.371Z" },
@@ -228,37 +228,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -826,7 +826,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -838,7 +838,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -868,9 +868,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -882,7 +882,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -1033,6 +1033,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/1b/2024d06792d0779f9dbc51531b61c24f76c75b9f4ce05e6f3377a1814cea/orjson-3.11.8.tar.gz", hash = "sha256:96163d9cdc5a202703e9ad1b9ae757d5f0ca62f4fa0cc93d1f27b0e180cc404e", size = 5603832, upload-time = "2026-03-31T16:16:27.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/35/b01910c3d6b85dc882442afe5060cbf719c7d1fc85749294beda23d17873/orjson-3.11.8-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:ec795530a73c269a55130498842aaa762e4a939f6ce481a7e986eeaa790e9da4", size = 229171, upload-time = "2026-03-31T16:16:00.651Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/56/c9ec97bd11240abef39b9e5d99a15462809c45f677420fd148a6c5e6295e/orjson-3.11.8-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:c492a0e011c0f9066e9ceaa896fbc5b068c54d365fea5f3444b697ee01bc8625", size = 128746, upload-time = "2026-03-31T16:16:02.673Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/66d4f30a90de45e2f0cbd9623588e8ae71eef7679dbe2ae954ed6d66a41f/orjson-3.11.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:883206d55b1bd5f5679ad5e6ddd3d1a5e3cac5190482927fdb8c78fb699193b5", size = 131867, upload-time = "2026-03-31T16:16:04.342Z" },
+    { url = "https://files.pythonhosted.org/packages/19/30/2a645fc9286b928675e43fa2a3a16fb7b6764aa78cc719dc82141e00f30b/orjson-3.11.8-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5774c1fdcc98b2259800b683b19599c133baeb11d60033e2095fd9d4667b82db", size = 124664, upload-time = "2026-03-31T16:16:05.837Z" },
+    { url = "https://files.pythonhosted.org/packages/db/44/77b9a86d84a28d52ba3316d77737f6514e17118119ade3f91b639e859029/orjson-3.11.8-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ac7381c83dd3d4a6347e6635950aa448f54e7b8406a27c7ecb4a37e9f1ae08b", size = 129701, upload-time = "2026-03-31T16:16:07.407Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ea/eff3d9bfe47e9bc6969c9181c58d9f71237f923f9c86a2d2f490cd898c82/orjson-3.11.8-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:14439063aebcb92401c11afc68ee4e407258d2752e62d748b6942dad20d2a70d", size = 141202, upload-time = "2026-03-31T16:16:09.48Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c8/90d4b4c60c84d62068d0cf9e4d8f0a4e05e76971d133ac0c60d818d4db20/orjson-3.11.8-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fa72e71977bff96567b0f500fc5bfd2fdf915f34052c782a4c6ebbdaa97aa858", size = 127194, upload-time = "2026-03-31T16:16:11.02Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c7/ea9e08d1f0ba981adffb629811148b44774d935171e7b3d780ae43c4c254/orjson-3.11.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7679bc2f01bb0d219758f1a5f87bb7c8a81c0a186824a393b366876b4948e14f", size = 133639, upload-time = "2026-03-31T16:16:13.434Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/8c/ddbbfd6ba59453c8fc7fe1d0e5983895864e264c37481b2a791db635f046/orjson-3.11.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14f7b8fcb35ef403b42fa5ecfa4ed032332a91f3dc7368fbce4184d59e1eae0d", size = 141914, upload-time = "2026-03-31T16:16:14.955Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/31/dbfbefec9df060d34ef4962cd0afcb6fa7a9ec65884cb78f04a7859526c3/orjson-3.11.8-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c2bdf7b2facc80b5e34f48a2d557727d5c5c57a8a450de122ae81fa26a81c1bc", size = 423800, upload-time = "2026-03-31T16:16:16.594Z" },
+    { url = "https://files.pythonhosted.org/packages/87/cf/f74e9ae9803d4ab46b163494adba636c6d7ea955af5cc23b8aaa94cfd528/orjson-3.11.8-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ccd7ba1b0605813a0715171d39ec4c314cb97a9c85893c2c5c0c3a3729df38bf", size = 147837, upload-time = "2026-03-31T16:16:18.585Z" },
+    { url = "https://files.pythonhosted.org/packages/64/e6/9214f017b5db85e84e68602792f742e5dc5249e963503d1b356bee611e01/orjson-3.11.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cdbc8c9c02463fef4d3c53a9ba3336d05496ec8e1f1c53326a1e4acc11f5c600", size = 136441, upload-time = "2026-03-31T16:16:20.151Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dd/3590348818f58f837a75fb969b04cdf187ae197e14d60b5e5a794a38b79d/orjson-3.11.8-cp314-cp314-win32.whl", hash = "sha256:0b57f67710a8cd459e4e54eb96d5f77f3624eba0c661ba19a525807e42eccade", size = 131983, upload-time = "2026-03-31T16:16:21.823Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/0f/b6cb692116e05d058f31ceee819c70f097fa9167c82f67fabe7516289abc/orjson-3.11.8-cp314-cp314-win_amd64.whl", hash = "sha256:735e2262363dcbe05c35e3a8869898022af78f89dde9e256924dc02e99fe69ca", size = 127396, upload-time = "2026-03-31T16:16:23.685Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d1/facb5b5051fabb0ef9d26c6544d87ef19a939a9a001198655d0d891062dd/orjson-3.11.8-cp314-cp314-win_arm64.whl", hash = "sha256:6ccdea2c213cf9f3d9490cbd5d427693c870753df41e6cb375bd79bcbafc8817", size = 127330, upload-time = "2026-03-31T16:16:25.496Z" },
 ]
 
 [[package]]
@@ -1837,6 +1860,7 @@ dependencies = [
     { name = "langfuse" },
     { name = "neo4j" },
     { name = "openai" },
+    { name = "orjson" },
     { name = "prompt-toolkit" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -1864,6 +1888,7 @@ requires-dist = [
     { name = "langfuse", specifier = ">=4.0,<5.0" },
     { name = "neo4j", specifier = ">=5.20" },
     { name = "openai", specifier = ">=1.40" },
+    { name = "orjson", specifier = ">=3.11.8" },
     { name = "prompt-toolkit", specifier = ">=3.0" },
     { name = "pydantic-settings", specifier = ">=2.3" },
     { name = "python-dotenv", specifier = ">=1.0" },


### PR DESCRIPTION
- Add Streamlit web UI (src/stylemind/ui/) with SSE streaming client, boutique CSS components, sidebar persona panel, and slash commands (/persona, /explain, /outfit, /help, /reset, /debug)
- Move FastAPI to port 8001; Streamlit web UI serves on port 8000
- Add make web-chat target; update Dockerfile and docker-compose port mappings
- Update README to make web-chat the default interface with dual Chat Interfaces section (Web UI + Terminal CLI)
- Add streamlit>=1.40 dependency
- Improve reranker, persona inference, graph queries, and RAG modules
- Expand test suite: new tests for API, persona inference, persona manager